### PR TITLE
VCST-1722: Manufacturer Part Number should be accessible

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -180,7 +180,8 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             Field(d => d.IndexedProduct.OuterId, nullable: true).Description("The outer identifier");
 
-            Field(d => d.IndexedProduct.Gtin, nullable: true).Description("Global Trade Item Number");
+            Field(d => d.IndexedProduct.Gtin, nullable: true).Description("Global Trade Item Number (GTIN)");
+            Field(d => d.IndexedProduct.ManufacturerPartNumber, nullable: true).Description("Manufacturer Part Number (MPN)");
 
             Field<StringGraphType>(
                 "brandName",


### PR DESCRIPTION
## Description
feat: feat: Manufacturer Part Number (MPN) should be accessible. A manufacturer part number (MPN) is a unique alphanumeric code assigned by a manufacturer to identify a specific product or component. It is used primarily for part tracking in inventory

![image](https://github.com/user-attachments/assets/fa1c96a2-38f0-4d5b-bb93-b2bbdf018312)


## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-1722
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.807.0-pr-10-8f05.zip