### PR TITLE
VCST-1811: Extend Product schema with PackSize

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -74,7 +74,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             Field(d => d.IndexedProduct.ProductType, nullable: true).Description("The type of product");
             Field(d => d.IndexedProduct.MinQuantity, nullable: true).Description("Min. quantity");
             Field(d => d.IndexedProduct.MaxQuantity, nullable: true).Description("Max. quantity");
-            Field(d => d.IndexedProduct.PackSize, nullable: false).Description("Defines the number of items in a package.");
+            Field(d => d.IndexedProduct.PackSize, nullable: false).Description("Defines the number of items in a package. Quantity step for your product's.");
 
             FieldAsync<StringGraphType>("outline", resolve: async context =>
             {

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -74,6 +74,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             Field(d => d.IndexedProduct.ProductType, nullable: true).Description("The type of product");
             Field(d => d.IndexedProduct.MinQuantity, nullable: true).Description("Min. quantity");
             Field(d => d.IndexedProduct.MaxQuantity, nullable: true).Description("Max. quantity");
+            Field(d => d.IndexedProduct.PackSize, nullable: false).Description("Defines the number of items in a package.");
 
             FieldAsync<StringGraphType>("outline", resolve: async context =>
             {

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
@@ -53,6 +53,12 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 resolve: context => context.Source.IndexedProduct.MaxQuantity
             );
 
+            Field<IntGraphType>(
+               "packSize",
+               description: "Defines the number of items in a package.",
+               resolve: context => context.Source.IndexedProduct.PackSize
+           );
+
             ExtendableField<NonNullGraphType<AvailabilityDataType>>(
                 "availabilityData",
                 "Availability data",

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
@@ -55,7 +55,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             Field<IntGraphType>(
                "packSize",
-               description: "Defines the number of items in a package.",
+               description: "Defines the number of items in a package. Quantity step for your product's.",
                resolve: context => context.Source.IndexedProduct.PackSize
            );
 

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.800.0" />
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.807.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.818.0-alpha.2234-vcst-1811-pack-size" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.800.0" />

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.800.0" />
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.818.0-alpha.2234-vcst-1811-pack-size" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.820.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.800.0" />

--- a/src/VirtoCommerce.XCatalog.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Extensions/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ namespace VirtoCommerce.XCatalog.Data.Extensions
             {
                 builder.AddMiddleware(typeof(EnsureCatalogProductLoadedMiddleware));
                 builder.AddMiddleware(typeof(RemoveNullCatalogProductsMiddleware));
+                builder.AddMiddleware(typeof(PackSizeResolveMiddleware));
                 builder.AddMiddleware(typeof(EvalProductsPricesMiddleware));
                 builder.AddMiddleware(typeof(EvalProductsDiscountsMiddleware));
                 builder.AddMiddleware(typeof(EvalProductsTaxMiddleware));

--- a/src/VirtoCommerce.XCatalog.Data/Middlewares/PackSizeResolveMiddleware.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Middlewares/PackSizeResolveMiddleware.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using PipelineNet.Middleware;
+using VirtoCommerce.XCatalog.Core.Models;
+
+namespace VirtoCommerce.XCatalog.Data.Middlewares
+{
+    public class PackSizeResolveMiddleware : IAsyncMiddleware<SearchProductResponse>
+    {
+        public Task Run(SearchProductResponse parameter, Func<SearchProductResponse, Task> next)
+        {
+            var productsWithPackSize = parameter.Results.Where(expProduct => expProduct.IndexedProduct.PackSize > 1).Select(x => x.IndexedProduct);
+
+            foreach (var product in productsWithPackSize)
+            {
+                var minQuantity = Math.Max(product.MinQuantity ?? 1, product.PackSize);
+                // Ensure minQuantity is a multiple of PackSize
+                if (minQuantity % product.PackSize > 0)
+                {
+                    minQuantity = (minQuantity / product.PackSize + 1) * product.PackSize;
+                }
+                product.MinQuantity = minQuantity;
+            }
+
+            return next(parameter);
+        }
+    }
+}

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -7,7 +7,7 @@
   <platformVersion>3.841.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Xapi" version="3.800.0" />
-    <dependency id="VirtoCommerce.Catalog" version="3.800.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.820.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.800.0" optional="true" />
     <dependency id="VirtoCommerce.Marketing" version="3.800.0" optional="true" />
     <dependency id="VirtoCommerce.Pricing" version="3.800.0" optional="true" />


### PR DESCRIPTION
## Description
feat: Extends Product schema with PackSize

## References
### QA-test:
### Jira-link:




https://virtocommerce.atlassian.net/browse/VCST-1811
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.809.0-pr-12-266e.zip