### PR TITLE
VCST-2009: single value variations fix

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Binding/VariationsBinder.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Binding/VariationsBinder.cs
@@ -12,9 +12,15 @@ namespace VirtoCommerce.XCatalog.Core.Binding
         {
             var fieldName = BindingInfo.FieldName;
 
-            return searchDocument.TryGetValue(fieldName, out var value) && value is object[] objs
-                ? objs.Select(x => (string)x).ToList()
+            return searchDocument.TryGetValue(fieldName, out var value)
+                  ? value switch
+                 {
+                   object[] objs => objs.Select(x => (string)x).ToList(),
+                   string str => new List<string> { str },
+                   _ => Enumerable.Empty<string>().ToList()
+                 }
                 : Enumerable.Empty<string>().ToList();
+
         }
     }
 }

--- a/src/VirtoCommerce.XCatalog.Core/Binding/VariationsBinder.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Binding/VariationsBinder.cs
@@ -12,15 +12,16 @@ namespace VirtoCommerce.XCatalog.Core.Binding
         {
             var fieldName = BindingInfo.FieldName;
 
-            return searchDocument.TryGetValue(fieldName, out var value)
+            var result = searchDocument.TryGetValue(fieldName, out var value)
                   ? value switch
-                 {
-                   object[] objs => objs.Select(x => (string)x).ToList(),
-                   string str => new List<string> { str },
-                   _ => Enumerable.Empty<string>().ToList()
-                 }
-                : Enumerable.Empty<string>().ToList();
+                  {
+                      object[] objs => objs.Select(x => (string)x).ToList(),
+                      string str => [str],
+                      _ => Enumerable.Empty<string>().ToList()
+                  }
+                  : Enumerable.Empty<string>().ToList();
 
+            return result;
         }
     }
 }


### PR DESCRIPTION
## Description
1. Set Lucene search provider
2. Add a product with a single variation
3. Index the product
4. _variations in the index document will look like this (string instead of an array of string):
![image](https://github.com/user-attachments/assets/2d8d403b-b94a-4863-b80c-62ab9c552654)
5. Expected result: 
![image](https://github.com/user-attachments/assets/cdb31311-a201-47a3-a340-f3672ba1afaa)
6. Actual result: no variations returned
## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-2009
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.816.0-pr-18-b386.zip