### PR TITLE
VCST-2704: Refactor term filter logic and change Outline selection

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Extensions/IFiltertExtensions.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Extensions/IFiltertExtensions.cs
@@ -62,7 +62,10 @@ namespace VirtoCommerce.XCatalog.Core.Extensions
                 {
                     case TermFilter termFilter:
                         // For term filters: just check result value in filter values
-                        aggregationItem.IsApplied = termFilter.Values.Any(x => x.EqualsInvariant(aggregationItem.Value?.ToString()));
+                        if (termFilter.Values.Any(x => x.EqualsInvariant(aggregationItem.Value?.ToString())))
+                        {
+                            aggregationItem.IsApplied = true;
+                        }
                         break;
                     case RangeFilter rangeFilter:
                         // For range filters check the values have the same bounds

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
@@ -155,7 +155,7 @@ namespace VirtoCommerce.XCatalog.Data.Queries
                 .Where(o => !string.IsNullOrEmpty(o))
                 .ToArray();
 
-            criteria.Outline = criteria.Outlines.MaxBy(x => x.Length);
+            criteria.Outline = criteria.Outlines.MinBy(x => x.Length);
         }
 
         protected virtual Task<Aggregation[]> ConvertAggregations(SearchResponse searchResponse, SearchRequest searchRequest, ProductIndexedSearchCriteria criteria)


### PR DESCRIPTION
## Description
fix: Refactor term filter logic in IFiltertExtensions.cs to improve readability and debugging by using an explicit if statement. Change Outline selection in SearchProductQueryHandler.cs to choose the shortest outline instead of the longest.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2704
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.905.0-pr-32-6569.zip