### PR TITLE
VCST-2688: add property group field

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
@@ -1,5 +1,7 @@
+using GraphQL;
 using GraphQL.Types;
 using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Schemas;
 
@@ -13,32 +15,26 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             Description = "Property group.";
 
             Field(x => x.Id, nullable: false).Description("The unique ID of the property group.");
-            Field(x => x.Name, nullable: false).Description("The name of the property group.");
             Field(x => x.Priority, nullable: true).Description("The display order of the property group.");
 
-            Field<StringGraphType>("localizedName").Resolve(context =>
-            {
-                var cultureName = context.GetArgumentOrValue<string>("cultureName");
-                var group = context.Source;
-                var localizedName = group.LocalizedName?.GetValue(cultureName);
-                if (!string.IsNullOrEmpty(localizedName))
-                {
-                    return localizedName;
-                }
-                return group.Name;
-            }).Description("The localized name of the property group.");
+            Field<StringGraphType>("name")
+                .Resolve(context => GetLocalizedValue(context, context.Source.LocalizedName, context.Source.Name))
+                .Description("The localized name of the property group.");
 
-            Field<StringGraphType>("localizedDescription").Resolve(context =>
+            Field<StringGraphType>("description")
+                .Resolve(context => GetLocalizedValue(context, context.Source.LocalizedDescription))
+                .Description("The localized description of the property group.");
+        }
+
+        private static string GetLocalizedValue(IResolveFieldContext<PropertyGroup> context, LocalizedString localizedString, string fallbackValue = null)
+        {
+            var cultureName = context.GetArgumentOrValue<string>("cultureName");
+            var localizedValue = localizedString?.GetValue(cultureName);
+            if (!string.IsNullOrEmpty(localizedValue))
             {
-                var cultureName = context.GetArgumentOrValue<string>("cultureName");
-                var group = context.Source;
-                var localizedDescription = group.LocalizedDescription?.GetValue(cultureName);
-                if (!string.IsNullOrEmpty(localizedDescription))
-                {
-                    return localizedDescription;
-                }
-                return null;
-            }).Description("The localized description of the property group.");
+                return localizedValue;
+            }
+            return fallbackValue;
         }
     }
 }

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             Field(x => x.Name, nullable: false).Description("The name of the property group.");
             Field(x => x.Priority, nullable: true).Description("The display order of the property group.");
 
-            Field<NonNullGraphType<StringGraphType>>("localizedName").Resolve(context =>
+            Field<StringGraphType>("localizedName").Resolve(context =>
             {
                 var cultureName = context.GetArgumentOrValue<string>("cultureName");
                 var group = context.Source;
@@ -28,7 +28,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 return group.Name;
             }).Description("The localized name of the property group.");
 
-            Field<NonNullGraphType<StringGraphType>>("localizedDescription").Resolve(context =>
+            Field<StringGraphType>("localizedDescription").Resolve(context =>
             {
                 var cultureName = context.GetArgumentOrValue<string>("cultureName");
                 var group = context.Source;

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
@@ -27,6 +27,18 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 }
                 return group.Name;
             }).Description("The localized name of the property group.");
+
+            Field<NonNullGraphType<StringGraphType>>("localizedDescription").Resolve(context =>
+            {
+                var cultureName = context.GetArgumentOrValue<string>("cultureName");
+                var group = context.Source;
+                var localizedDescription = group.LocalizedDescription?.GetValue(cultureName);
+                if (!string.IsNullOrEmpty(localizedDescription))
+                {
+                    return localizedDescription;
+                }
+                return null;
+            }).Description("The localized description of the property group.");
         }
     }
 }

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
@@ -15,7 +15,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             Description = "Property group.";
 
             Field(x => x.Id, nullable: false).Description("The unique ID of the property group.");
-            Field(x => x.Priority, nullable: true).Description("The display order of the property group.");
+            Field(x => x.DisplayOrder, nullable: true).Description("The display order of the property group.");
 
             Field<StringGraphType>("name")
                 .Resolve(context => GetLocalizedValue(context, context.Source.LocalizedName, context.Source.Name))

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
@@ -26,7 +26,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 .Description("The localized description of the property group.");
         }
 
-        private static string GetLocalizedValue(IResolveFieldContext<PropertyGroup> context, LocalizedString localizedString, string fallbackValue = null)
+        private static string GetLocalizedValue(IResolveFieldContext context, LocalizedString localizedString, string fallbackValue = null)
         {
             var cultureName = context.GetArgumentOrValue<string>("cultureName");
             var localizedValue = localizedString?.GetValue(cultureName);

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
@@ -1,0 +1,32 @@
+using GraphQL.Types;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.Xapi.Core.Extensions;
+using VirtoCommerce.Xapi.Core.Schemas;
+
+namespace VirtoCommerce.XCatalog.Core.Schemas
+{
+    public class PropertyGroupType : ExtendableGraphType<PropertyGroup>
+    {
+        public PropertyGroupType()
+        {
+            Name = "PropertyGroup";
+            Description = "Property group.";
+
+            Field(x => x.Id, nullable: false).Description("The unique ID of the property group.");
+            Field(x => x.Name, nullable: false).Description("The name of the property group.");
+            Field(x => x.Priority, nullable: true).Description("The display order of the property group.");
+
+            Field<NonNullGraphType<StringGraphType>>("localizedName").Resolve(context =>
+            {
+                var cultureName = context.GetArgumentOrValue<string>("cultureName");
+                var group = context.Source;
+                var localizedName = group.LocalizedName?.GetValue(cultureName);
+                if (!string.IsNullOrEmpty(localizedName))
+                {
+                    return localizedName;
+                }
+                return group.Name;
+            }).Description("The localized name of the property group.");
+        }
+    }
+}

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyGroupType.cs
@@ -29,11 +29,16 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
         private static string GetLocalizedValue(IResolveFieldContext context, LocalizedString localizedString, string fallbackValue = null)
         {
             var cultureName = context.GetArgumentOrValue<string>("cultureName");
-            var localizedValue = localizedString?.GetValue(cultureName);
-            if (!string.IsNullOrEmpty(localizedValue))
+
+            if (!string.IsNullOrEmpty(cultureName))
             {
-                return localizedValue;
+                var localizedValue = localizedString?.GetValue(cultureName);
+                if (!string.IsNullOrEmpty(localizedValue))
+                {
+                    return localizedValue;
+                }
             }
+
             return fallbackValue;
         }
     }

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyType.cs
@@ -1,12 +1,16 @@
 using System.Linq;
 using System.Threading.Tasks;
+using GraphQL;
 using GraphQL.Builders;
 using GraphQL.DataLoader;
+using GraphQL.Resolvers;
 using GraphQL.Types;
 using MediatR;
 using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Xapi.Core.Extensions;
+using VirtoCommerce.Xapi.Core.Helpers;
 using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.Xapi.Core.Schemas;
 using VirtoCommerce.XCatalog.Core.Queries;
@@ -17,7 +21,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 {
     public class PropertyType : ExtendableGraphType<Property>
     {
-        public PropertyType(IMediator mediator, IDataLoaderContextAccessor dataLoader)
+        public PropertyType(IMediator mediator, IDataLoaderContextAccessor dataLoader, IPropertyGroupService propertyGroupService)
         {
             Name = "Property";
             Description = "Products attributes.";
@@ -66,6 +70,23 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             Field<StringGraphType>("valueId")
                 .Resolve(context => context.Source.Values.Select(x => x.ValueId).FirstOrDefault());
+
+            var group = new FieldType
+            {
+                Name = "group",
+                Type = GraphTypeExtensionHelper.GetActualType<PropertyGroupType>(),
+                Resolver = new FuncFieldResolver<Property, IDataLoaderResult<PropertyGroup>>(context =>
+                {
+                    var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToArray();
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, PropertyGroup>("propertyGroupLoader", async (ids) =>
+                    {
+                        var groups = await propertyGroupService.GetNoCloneAsync(ids.ToList());
+                        return groups.ToDictionary(x => x.Id);
+                    });
+                    return loader.LoadAsync(context.Source.PropertyGroupId);
+                })
+            };
+            AddField(group);
 
             Connection<PropertyDictionaryItemType>("propertyDictionaryItems")
                 .PageSize(Connections.DefaultPageSize)

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyType.cs
@@ -77,7 +77,6 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<PropertyGroupType>(),
                 Resolver = new FuncFieldResolver<Property, IDataLoaderResult<PropertyGroup>>(context =>
                 {
-                    var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToArray();
                     var loader = dataLoader.Context.GetOrAddBatchLoader<string, PropertyGroup>("propertyGroupLoader", async (ids) =>
                     {
                         var groups = await propertyGroupService.GetNoCloneAsync(ids.ToList());

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>True</IsPackable>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.854.0-alpha.2322-vcst-2688" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.856.0-alpha.2334-vcst-2688" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.805.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.815.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.809.0" />

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.852.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.854.0-alpha.2322-vcst-2688" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.805.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.815.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.809.0" />

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.856.0-alpha.2334-vcst-2688" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.858.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.805.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.815.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.809.0" />

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.877.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.854.0-alpha.2322-vcst-2688" />
+    <dependency id="VirtoCommerce.Catalog" version="3.856.0-alpha.2334-vcst-2688" />
     <dependency id="VirtoCommerce.Inventory" version="3.805.0" optional="true" />
     <dependency id="VirtoCommerce.Marketing" version="3.815.0" optional="true" />
     <dependency id="VirtoCommerce.Pricing" version="3.809.0" optional="true" />

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.877.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.856.0-alpha.2334-vcst-2688" />
+    <dependency id="VirtoCommerce.Catalog" version="3.858.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.805.0" optional="true" />
     <dependency id="VirtoCommerce.Marketing" version="3.815.0" optional="true" />
     <dependency id="VirtoCommerce.Pricing" version="3.809.0" optional="true" />

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.877.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.852.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.854.0-alpha.2322-vcst-2688" />
     <dependency id="VirtoCommerce.Inventory" version="3.805.0" optional="true" />
     <dependency id="VirtoCommerce.Marketing" version="3.815.0" optional="true" />
     <dependency id="VirtoCommerce.Pricing" version="3.809.0" optional="true" />

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/PropertyTypeTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/PropertyTypeTests.cs
@@ -14,7 +14,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
 {
     public class PropertyTypeTests : XCatalogMoqHelper
     {
-        private readonly PropertyType _propertyType = new(null, null);
+        private readonly PropertyType _propertyType = new(null, null, null);
 
         [Fact]
         public async Task PropertyType_Properties_ShouldFilterPropertiesByCultureName()

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/PropertyTypeTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/PropertyTypeTests.cs
@@ -14,7 +14,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
 {
     public class PropertyTypeTests : XCatalogMoqHelper
     {
-        private readonly PropertyType _propertyType = new(null, null, null);
+        private readonly PropertyType _propertyType = new(null, null, null, null);
 
         [Fact]
         public async Task PropertyType_Properties_ShouldFilterPropertiesByCultureName()


### PR DESCRIPTION
## Description
Added `Group field` of type `PropertyGroupType` to `PropertyType`:

```graphql
query products {
  products(
    first:20
    storeId: "Electronics", 
    currencyCode: "EUR", 
    cultureName: "de-DE",
  )
  {
    totalCount
    items {     
     id
     code
     name
     properties {
      name
      group {
        id
        name
        displayOrder
        description
        }
      }
    }
  }
}
```

## References
### QA-test:
### Jira-link:









https://virtocommerce.atlassian.net/browse/VCST-2688
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.914.0-pr-44-7848.zip