### PR TITLE
Allow pricelist names to be retrieved through GraphQL

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Schemas/PriceType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/PriceType.cs
@@ -50,6 +50,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 .Resolve(context => context.Source.Discounts);
 
             Field(d => d.PricelistId, nullable: true).Description("The product price list");
+            Field(d => d.PricelistName, nullable: true).Description("The product price list name");
             Field(d => d.MinQuantity, nullable: true).Description("The product min qty");
         }
     }

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -14,6 +14,6 @@
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.805.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.815.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.809.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.906.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.913.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XCatalog.Data/Middlewares/EvalProductsPricesMiddleware.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Middlewares/EvalProductsPricesMiddleware.cs
@@ -69,6 +69,7 @@ namespace VirtoCommerce.XCatalog.Data.Middlewares
                     {
                         options.Items["all_currencies"] = parameter.AllStoreCurrencies;
                         options.Items["currency"] = parameter.Currency;
+                        options.Items["pricelists"] = evalContext.Pricelists;
                     }).ToList();
 
                     product.ApplyStaticDiscounts();

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -10,7 +10,7 @@
     <dependency id="VirtoCommerce.Inventory" version="3.805.0" optional="true" />
     <dependency id="VirtoCommerce.Marketing" version="3.815.0" optional="true" />
     <dependency id="VirtoCommerce.Pricing" version="3.809.0" optional="true" />
-    <dependency id="VirtoCommerce.Xapi" version="3.906.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.913.0" />
   </dependencies>
 
   <title>Catalog Experience API</title>


### PR DESCRIPTION
- Ensure the Pricelists are passed onto the mapping through the EvalProductsPricesMiddleware.
- Ensure Pricelists are retrieved in the mapping profile and set on the price object.
- Add the PricelistName property to the PriceType.

## Description

## References
### QA-test:
### Jira-link:
### Artifact URL:
