### PR TITLE
VCST-4729: Sort term labels according to Aggregation filter name sorting type

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1006.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1014.0-alpha.2496-vcst-4729-terms-sorting" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1014.0-alpha.2496-vcst-4729-terms-sorting" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1017.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.XCatalog.Data/Mapping/FacetMappingProfile.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Mapping/FacetMappingProfile.cs
@@ -3,8 +3,10 @@ using System.Globalization;
 using System.Linq;
 using AutoMapper;
 using VirtoCommerce.CatalogModule.Core.Model.Search;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Models.Facets;
+using CatalogModuleConstants = VirtoCommerce.CatalogModule.Core.ModuleConstants;
 using CoreFacets = VirtoCommerce.Xapi.Core.Models.Facets;
 
 namespace VirtoCommerce.XCatalog.Data.Mapping
@@ -13,13 +15,13 @@ namespace VirtoCommerce.XCatalog.Data.Mapping
     {
         public FacetMappingProfile()
         {
-            CreateMap<Aggregation, CoreFacets.FacetResult>().IncludeAllDerived().ConvertUsing((request, facet, context) =>
+            CreateMap<Aggregation, FacetResult>().IncludeAllDerived().ConvertUsing((request, facet, context) =>
             {
                 context.Items.TryGetValue("cultureName", out var cultureNameObj);
                 var cultureName = cultureNameObj as string;
-                CoreFacets.FacetResult result = request.AggregationType switch
+                FacetResult result = request.AggregationType switch
                 {
-                    "attr" => new CoreFacets.TermFacetResult
+                    "attr" => new TermFacetResult
                     {
                         Terms = request.Items?.Select(x => new CoreFacets.FacetTerm
                         {
@@ -32,9 +34,9 @@ namespace VirtoCommerce.XCatalog.Data.Mapping
                             .ToArray() ?? [],
                         Name = request.Field
                     },
-                    "range" or "pricerange" => new CoreFacets.RangeFacetResult
+                    "range" or "pricerange" => new RangeFacetResult
                     {
-                        Ranges = request.Items?.Select(x => new CoreFacets.FacetRange
+                        Ranges = request.Items?.Select(x => new FacetRange
                         {
                             Count = x.Count,
                             From = ToNullableDecimal(x.RequestedLowerBound),
@@ -66,10 +68,32 @@ namespace VirtoCommerce.XCatalog.Data.Mapping
                     {
                         result.Order = (int)orderObj;
                     }
+
+                    SortTermFacetResultByLabels(request, result);
                 }
 
                 return result;
             });
+        }
+
+        private static void SortTermFacetResultByLabels(Aggregation request, FacetResult result)
+        {
+            if (result is not TermFacetResult termFacetResult || termFacetResult.Terms.IsNullOrEmpty())
+            {
+                return;
+            }
+
+            // assume NameAcsending is the default method of sorting by term label
+            // or sort descening by term lable
+            // no need to resort by score or priority (already sorted by Catalog Module).
+            if (request.TermValuesSortingType.IsNullOrEmpty() || request.TermValuesSortingType.EqualsIgnoreCase(CatalogModuleConstants.TermValuesSortingTypeNameAscending))
+            {
+                termFacetResult.Terms = termFacetResult.Terms.OrderBy(x => x.Label).ToArray();
+            }
+            else if (request.TermValuesSortingType.EqualsIgnoreCase(CatalogModuleConstants.TermValuesSortingTypeNameDescending))
+            {
+                termFacetResult.Terms = termFacetResult.Terms.OrderByDescending(x => x.Label).ToArray();
+            }
         }
 
         private static decimal? ToNullableDecimal(string value)

--- a/src/VirtoCommerce.XCatalog.Data/Middlewares/EvalSearchRequestUserGroupsMiddleware.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Middlewares/EvalSearchRequestUserGroupsMiddleware.cs
@@ -6,7 +6,6 @@ using PipelineNet.Middleware;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.Platform.Core.Common;
-using VirtoCommerce.Platform.Core.Extensions;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.Xapi.Core;
@@ -18,18 +17,18 @@ namespace VirtoCommerce.XCatalog.Data.Middlewares
     {
         private readonly IMemberResolver _memberResolver;
         private readonly IMemberService _memberService;
-        private readonly IModuleCatalog _moduleCatalog;
+        private readonly IModuleService _moduleService;
 
-        public EvalSearchRequestUserGroupsMiddleware(IMemberResolver memberResolver, IMemberService memberService, IModuleCatalog moduleCatalog)
+        public EvalSearchRequestUserGroupsMiddleware(IMemberResolver memberResolver, IMemberService memberService, IModuleService moduleService)
         {
             _memberResolver = memberResolver;
             _memberService = memberService;
-            _moduleCatalog = moduleCatalog;
+            _moduleService = moduleService;
         }
 
         public virtual async Task Run(IndexSearchRequestBuilder parameter, Func<IndexSearchRequestBuilder, Task> next)
         {
-            if (parameter != null && _moduleCatalog.IsModuleInstalled("VirtoCommerce.CatalogPersonalization"))
+            if (parameter != null && _moduleService.IsInstalled("VirtoCommerce.CatalogPersonalization"))
             {
                 var userGroups = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "__any" };
 

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.1006.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1014.0-alpha.2496-vcst-4729-terms-sorting" />
     <dependency id="VirtoCommerce.Inventory" version="3.1000.0" optional="true" />
     <dependency id="VirtoCommerce.Marketing" version="3.1000.0" optional="true" />
     <dependency id="VirtoCommerce.Pricing" version="3.1000.0" optional="true" />

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -4,9 +4,9 @@
   <version>3.1004.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1013.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.1014.0-alpha.2496-vcst-4729-terms-sorting" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1017.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.1000.0" optional="true" />
     <dependency id="VirtoCommerce.Marketing" version="3.1000.0" optional="true" />
     <dependency id="VirtoCommerce.Pricing" version="3.1000.0" optional="true" />

--- a/tests/VirtoCommerce.XCatalog.Tests/VirtoCommerce.XCatalog.Tests.csproj
+++ b/tests/VirtoCommerce.XCatalog.Tests/VirtoCommerce.XCatalog.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.1013.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.1004.0-pr-93-2ab1.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes facet term ordering and upgrades core dependencies, which can affect API response stability and downstream expectations even though the logic change is small.
> 
> **Overview**
> Facet mapping now **re-sorts `TermFacetResult.Terms` by `Label`** based on `Aggregation.TermValuesSortingType` (default/name-ascending or name-descending), ensuring term facets respect the requested name ordering.
> 
> Updates module/platform dependencies (Catalog `3.1006.0`→`3.1017.0`, Platform `3.1002.0`→`3.1013.0`) and switches `EvalSearchRequestUserGroupsMiddleware` to use `IModuleService.IsInstalled` instead of `IModuleCatalog.IsModuleInstalled` for the Catalog Personalization module check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab18de39dc5a99b0479c3db72f58ef8344500af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->