### PR TITLE
VCST-5011: Cannot cast System.Double to System.Decimal

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyType.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using GraphQL;
@@ -121,7 +123,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             var symbol = string.Empty;
             var valueUnit = measure.Units.FirstOrDefault(x => x.Id == propertyValue.UnitOfMeasureId);
-            var decimalValue = (decimal)propertyValue.Value;
+            var decimalValue = Convert.ToDecimal(propertyValue.Value, CultureInfo.InvariantCulture);
 
             if (valueUnit != null)
             {


### PR DESCRIPTION
## Description
fix: Cannot cast System.Double to System.Decimal

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5011
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.1005.0-pr-94-be14.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to GraphQL measure-value formatting; main risk is potential behavior change in decimal parsing for non-decimal inputs/cultures.
> 
> **Overview**
> Fixes measure-valued property rendering in `PropertyType.ResolveValue` by replacing a direct `(decimal)` cast with `Convert.ToDecimal(..., CultureInfo.InvariantCulture)`, preventing runtime failures when the underlying value is a `double` (or other convertible numeric type).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be142e3d3b84c7607ac68dbba3765a1d988345b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->