### PR TITLE
VCST-5163: Stable 15 — XCatalog (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1017.0" />
-    <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1029.0" />
+    <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XCatalog.Web/VirtoCommerce.XCatalog.Web.csproj
+++ b/src/VirtoCommerce.XCatalog.Web/VirtoCommerce.XCatalog.Web.csproj
@@ -14,7 +14,7 @@
 
   <!-- [Obsolete("Added temporarily to avoid runtime errors until all dependent modules have been updated", DiagnosticId = "VC0010")] -->
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Tools" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Tools" Version="3.1007.0" />
   </ItemGroup>
 
 </Project>

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -4,13 +4,13 @@
   <version>3.1007.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1013.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.1017.0" />
-    <dependency id="VirtoCommerce.Inventory" version="3.1000.0" optional="true" />
-    <dependency id="VirtoCommerce.Marketing" version="3.1000.0" optional="true" />
-    <dependency id="VirtoCommerce.Pricing" version="3.1000.0" optional="true" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
+    <dependency id="VirtoCommerce.Inventory" version="3.1003.0" optional="true" />
+    <dependency id="VirtoCommerce.Marketing" version="3.1005.0" optional="true" />
+    <dependency id="VirtoCommerce.Pricing" version="3.1003.0" optional="true" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
   </dependencies>
 
   <title>Catalog Experience API</title>

--- a/tests/VirtoCommerce.XCatalog.Tests/VirtoCommerce.XCatalog.Tests.csproj
+++ b/tests/VirtoCommerce.XCatalog.Tests/VirtoCommerce.XCatalog.Tests.csproj
@@ -5,14 +5,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.1039.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
Part of **Stable 15** (Wave 8). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Waves 1–7 packages on nuget.org. Version handled by CI.

- Xapi dep bumped to 3.1012.0.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes across csproj, manifest, and test packages; risk is mainly compatibility with the new platform and module APIs at deploy time, not logic changes in this repo.
> 
> **Overview**
> **Stable 15 alignment** for the XCatalog module: no application source changes—only dependency and manifest version bumps so the module builds and runs against platform **3.1039.0** and the published Wave 1–7 module packages.
> 
> `module.manifest` raises **`platformVersion`** to **3.1039.0** and updates required/optional module dependencies (Catalog **3.1029.0**, Inventory **3.1003.0**, Marketing **3.1005.0**, Pricing **3.1003.0**, Xapi **3.1012.0**). **`VirtoCommerce.XCatalog.Core`** NuGet references match those module cores plus **Xapi.Core 3.1012.0**; **`VirtoCommerce.XCatalog.Web`** bumps **VirtoCommerce.Tools** to **3.1007.0**. Tests use **VirtoCommerce.Platform.Modules 3.1039.0** and **coverlet.collector 10.0.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 540b70942e1efb1e65942accba15a3302d3e1b7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.1007.0-pr-95-540b.zip