### PR TITLE
VCST-5289: categories x-api query ignores sort for nested childCategories

### DIFF
--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchCategoryQueryHandler.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchCategoryQueryHandler.cs
@@ -89,6 +89,7 @@ namespace VirtoCommerce.XCatalog.Data.Queries
                     UserId = request.UserId,
                     CultureName = request.CultureName,
                     CurrencyCode = request.CurrencyCode,
+                    Sort = request.Sort, // Propagate sorting to child categories (applies to all nested levels via recursion)
                 };
 
                 var regex = new Regex("^childCategories\\.");

--- a/tests/VirtoCommerce.XCatalog.Tests/Queries/SearchCategoryQueryHandlerTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Queries/SearchCategoryQueryHandlerTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.SearchModule.Core.Model;
+using VirtoCommerce.SearchModule.Core.Services;
+using VirtoCommerce.StoreModule.Core.Model;
+using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.Xapi.Core.Pipelines;
+using VirtoCommerce.Xapi.Tests.Helpers;
+using VirtoCommerce.XCatalog.Core.Models;
+using VirtoCommerce.XCatalog.Core.Queries;
+using VirtoCommerce.XCatalog.Data.Queries;
+using Xunit;
+
+namespace VirtoCommerce.XCatalog.Tests.Queries
+{
+    public class SearchCategoryQueryHandlerTests : BaseMoqHelper
+    {
+        private const string CATALOG_ID = "catalog-1";
+        private const string SCORE_FIELD = "score";
+
+        private readonly Mock<ISearchProvider> _searchProviderMock = new();
+        private readonly Mock<IMapper> _mapperMock = new();
+        private readonly Mock<ISearchPhraseParser> _phraseParserMock = new();
+        private readonly Mock<IStoreService> _storeServiceMock = new();
+        private readonly Mock<IGenericPipelineLauncher> _pipelineMock = new();
+
+        private readonly List<SearchRequest> _capturedSearchRequests = new();
+
+        public SearchCategoryQueryHandlerTests()
+        {
+            // Capture every SearchRequest reaching the search provider (top-level + each recursive child fetch).
+            _searchProviderMock
+                .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<SearchRequest>()))
+                .Callback<string, SearchRequest>((_, request) => _capturedSearchRequests.Add(request))
+                .ReturnsAsync(() => new SearchResponse
+                {
+                    TotalCount = 1,
+                    Documents = new List<SearchDocument> { new SearchDocument { Id = "doc-1" } },
+                });
+
+            // Each mapped category is a fresh instance with a null ChildCategories so the child-loading branch is entered.
+            _mapperMock
+                .Setup(x => x.Map<ExpCategory>(It.IsAny<object>(), It.IsAny<Action<IMappingOperationOptions<object, ExpCategory>>>()))
+                .Returns(() => new ExpCategory { Category = new Category { Id = "category-1" } });
+
+            // The child-categories lookup returns one child id so the recursive search is triggered.
+            _mediatorMock
+                .Setup(x => x.Send(It.IsAny<ChildCategoriesQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ChildCategoriesQueryResponse
+                {
+                    ChildCategories = new List<ExpCategory> { new ExpCategory { Key = "child-1" } },
+                });
+        }
+
+        private SearchCategoryQueryHandler GetHandler() => new SearchCategoryQueryHandler(
+            _searchProviderMock.Object,
+            _mapperMock.Object,
+            _phraseParserMock.Object,
+            _storeServiceMock.Object,
+            _pipelineMock.Object,
+            _mediatorMock.Object);
+
+        [Fact]
+        public async Task Handle_SearchCategory_WithSortAndChildCategories_PropagatesSortToChildSearch()
+        {
+            // Arrange
+            var query = new SearchCategoryQuery
+            {
+                Store = new Store { Id = DEFAULT_STORE_ID, Catalog = CATALOG_ID },
+                StoreId = DEFAULT_STORE_ID,
+                CultureName = CULTURE_NAME,
+                CurrencyCode = CURRENCY_CODE,
+                Sort = "priority;name",
+                IncludeFields = new List<string> { "childCategories.id" },
+            };
+
+            // Act
+            await GetHandler().Handle(query, CancellationToken.None);
+
+            // Assert
+            // Two searches must have run: the top-level one and the recursive child fetch.
+            _capturedSearchRequests.Should().HaveCount(2);
+
+            var childSearchRequest = _capturedSearchRequests[1];
+
+            // The child search must honor the requested sort (priority/name) rather than fall back to the default [score desc].
+            childSearchRequest.Sorting.Should().Contain(x => x.FieldName == "priority");
+            childSearchRequest.Sorting.Should().Contain(x => x.FieldName == "name");
+            childSearchRequest.Sorting.Should().NotContain(x => x.FieldName == SCORE_FIELD);
+        }
+    }
+}


### PR DESCRIPTION
## Description
fix: categories x-api query ignores sort for nested childCategories

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5289
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.1008.0-pr-96-b620.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field propagation in category search with a focused unit test; no auth, data migration, or API contract changes beyond correct sort ordering for nested categories.
> 
> **Overview**
> Fixes category x-api responses where **`childCategories`** were ordered by search defaults (e.g. score) even when the client passed **`sort`** on the parent query.
> 
> **`SearchCategoryQueryHandler`** now sets **`Sort = request.Sort`** on the reusable **`childCategoriesSearchQuery`** used for recursive child fetches, so the same sort applies at every nested level.
> 
> Adds **`SearchCategoryQueryHandlerTests`** with a test that loads **`childCategories`** with **`sort=priority;name`** and asserts the second (child) **`SearchRequest`** sorts by **`priority`** and **`name`**, not **`score`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b620d85c4df46e557c23fcc10f773c422302101b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->