### PR TITLE
VCST-5345: Expose associations field on VariationType in GraphQL 

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Extensions/ProductAssociationExtension.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Extensions/ProductAssociationExtension.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Builders;
+using MediatR;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+using VirtoCommerce.XCatalog.Core.Models;
+using VirtoCommerce.XCatalog.Core.Queries;
+
+namespace VirtoCommerce.XCatalog.Core.Extensions
+{
+    public static class ProductAssociationExtension
+    {
+        /// <summary>
+        /// Resolves the GraphQL associations connection for any product-like source (a product or its variation),
+        /// searching associations by the source item's own id. Shared by ProductType and VariationType.
+        /// </summary>
+        public static async Task<object> ResolveAssociationsConnectionAsync<TSource>(this IResolveConnectionContext<TSource> context, IMediator mediator)
+            where TSource : ExpProduct
+        {
+            var first = context.First;
+
+            int.TryParse(context.After, out var skip);
+
+            var query = new SearchProductAssociationsQuery
+            {
+                Skip = skip,
+                Take = first ?? context.PageSize ?? 10,
+
+                Keyword = context.GetArgument<string>("query"),
+                Group = context.GetArgument<string>("group"),
+                ObjectIds = [context.Source.IndexedProduct.Id]
+            };
+
+            var response = await mediator.Send(query);
+
+            return new PagedConnection<ProductAssociation>(response.Result.Results, query.Skip, query.Take, response.Result.TotalCount);
+        }
+    }
+}

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -400,7 +400,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
               .Argument<StringGraphType>("query", "the search phrase")
               .Argument<StringGraphType>("group", "association group (Accessories, RelatedItem)")
               .PageSize(Connections.DefaultPageSize)
-              .ResolveAsync(async context => await ResolveAssociationConnectionAsync(mediator, context));
+              .ResolveAsync(async context => await context.ResolveAssociationsConnectionAsync(mediator));
 
 
             Connection<VideoType>("videos")
@@ -439,27 +439,6 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             var response = await mediator.Send(query);
 
             return response.Products.Where(x => x.IndexedProduct?.IsActive == true).Select(expProduct => new ExpVariation(expProduct));
-        }
-
-        private static async Task<object> ResolveAssociationConnectionAsync(IMediator mediator, IResolveConnectionContext<ExpProduct> context)
-        {
-            var first = context.First;
-
-            int.TryParse(context.After, out var skip);
-
-            var query = new SearchProductAssociationsQuery
-            {
-                Skip = skip,
-                Take = first ?? context.PageSize ?? 10,
-
-                Keyword = context.GetArgument<string>("query"),
-                Group = context.GetArgument<string>("group"),
-                ObjectIds = [context.Source.IndexedProduct.Id]
-            };
-
-            var response = await mediator.Send(query);
-
-            return new PagedConnection<ProductAssociation>(response.Result.Results, query.Skip, query.Take, response.Result.TotalCount);
         }
 
         private static async Task<object> ResolveVideosConnectionAsync(IMediator mediator, IResolveConnectionContext<ExpProduct> context)

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
@@ -1,14 +1,10 @@
 using System;
 using System.Linq;
-using System.Threading.Tasks;
-using GraphQL;
-using GraphQL.Builders;
 using GraphQL.Types;
 using MediatR;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Xapi.Core.Extensions;
-using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.Xapi.Core.Models;
 using VirtoCommerce.Xapi.Core.Schemas;
 using VirtoCommerce.XCatalog.Core.Extensions;
@@ -115,28 +111,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
               .Argument<StringGraphType>("query", "the search phrase")
               .Argument<StringGraphType>("group", "association group (Accessories, RelatedItem)")
               .PageSize(Connections.DefaultPageSize)
-              .ResolveAsync(async context => await ResolveAssociationConnectionAsync(mediator, context));
-        }
-
-        private static async Task<object> ResolveAssociationConnectionAsync(IMediator mediator, IResolveConnectionContext<ExpVariation> context)
-        {
-            var first = context.First;
-
-            int.TryParse(context.After, out var skip);
-
-            var query = new SearchProductAssociationsQuery
-            {
-                Skip = skip,
-                Take = first ?? context.PageSize ?? 10,
-
-                Keyword = context.GetArgument<string>("query"),
-                Group = context.GetArgument<string>("group"),
-                ObjectIds = [context.Source.IndexedProduct.Id]
-            };
-
-            var response = await mediator.Send(query);
-
-            return new PagedConnection<ProductAssociation>(response.Result.Results, query.Skip, query.Take, response.Result.TotalCount);
+              .ResolveAsync(async context => await context.ResolveAssociationsConnectionAsync(mediator));
         }
     }
 }

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
@@ -1,15 +1,20 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Builders;
 using GraphQL.Types;
 using MediatR;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Xapi.Core.Extensions;
+using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.Xapi.Core.Models;
 using VirtoCommerce.Xapi.Core.Schemas;
 using VirtoCommerce.XCatalog.Core.Extensions;
 using VirtoCommerce.XCatalog.Core.Models;
 using VirtoCommerce.XCatalog.Core.Queries;
+using static VirtoCommerce.Xapi.Core.ModuleConstants;
 
 namespace VirtoCommerce.XCatalog.Core.Schemas
 {
@@ -105,6 +110,33 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 "rating",
                 "Product rating",
                 resolve: context => context.Source.Rating);
+
+            Connection<ProductAssociationType>("associations")
+              .Argument<StringGraphType>("query", "the search phrase")
+              .Argument<StringGraphType>("group", "association group (Accessories, RelatedItem)")
+              .PageSize(Connections.DefaultPageSize)
+              .ResolveAsync(async context => await ResolveAssociationConnectionAsync(mediator, context));
+        }
+
+        private static async Task<object> ResolveAssociationConnectionAsync(IMediator mediator, IResolveConnectionContext<ExpVariation> context)
+        {
+            var first = context.First;
+
+            int.TryParse(context.After, out var skip);
+
+            var query = new SearchProductAssociationsQuery
+            {
+                Skip = skip,
+                Take = first ?? context.PageSize ?? 10,
+
+                Keyword = context.GetArgument<string>("query"),
+                Group = context.GetArgument<string>("group"),
+                ObjectIds = [context.Source.IndexedProduct.Id]
+            };
+
+            var response = await mediator.Send(query);
+
+            return new PagedConnection<ProductAssociation>(response.Result.Results, query.Skip, query.Take, response.Result.TotalCount);
         }
     }
 }


### PR DESCRIPTION
## Description
feat: Added an associations connection to VariationType

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5345
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.1010.0-pr-98-0862.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema addition and refactor of existing association query logic; no auth or data-model changes beyond querying by variation id.
> 
> **Overview**
> Adds an **`associations`** GraphQL connection on **`VariationType`**, matching **`ProductType`** (`query`, `group`, pagination).
> 
> Association resolution is moved into **`ProductAssociationExtension.ResolveAssociationsConnectionAsync`**, keyed by the source item’s **`IndexedProduct.Id`**, and **`ProductType`** now calls that extension instead of a private resolver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 086294c2dc2804d7135edf957dcfcd0c074662eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->