### PR TITLE
VCST-5303: Cut property expansion cost (O(values^2) clone waste + per-request memoization)

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Extensions/PropertyExtensions.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Extensions/PropertyExtensions.cs
@@ -27,17 +27,22 @@ namespace VirtoCommerce.XCatalog.Core.Extensions
                                 // If localization not found build default value
                                 ?? aliasGroup.Select(propertyValue =>
                                 {
-                                    var clonedValue = (PropertyValue)propertyValue.Clone();
+                                    var clonedValue = propertyValue.CloneTyped();
                                     clonedValue.Value = aliasGroup.Key;
                                     return clonedValue;
                                 }).First()
                             )
                         : property.Values.Where(x => x.LanguageCode.EqualsIgnoreCase(cultureName) || x.LanguageCode.IsNullOrEmpty());
 
-                    // wrap each PropertyValue into a Property
+                    // Wrap each PropertyValue into a Property. Clone a values-free template once
+                    // per property instead of full-cloning per value: Property.Clone() deep-clones
+                    // ALL values, and the per-value copy immediately discards them — O(values²)
+                    // clone waste on the hot resolver path.
+                    var template = property.CopyPropertyWithoutValues();
+
                     return propertyValues
-                        .Select(propertyValue => propertyValue.CopyPropertyWithValue(property))
-                        .DefaultIfEmpty(property.CopyPropertyWithoutValues());
+                        .Select(propertyValue => template.CopyWithValue(propertyValue))
+                        .DefaultIfEmpty(template);
                 })
                 .ToList();
         }
@@ -88,14 +93,22 @@ namespace VirtoCommerce.XCatalog.Core.Extensions
 
         public static Property CopyPropertyWithValue(this PropertyValue propertyValue, Property property)
         {
-            var clonedProperty = (Property)property.Clone();
+            return property.CopyPropertyWithoutValues().CopyWithValue(propertyValue);
+        }
+
+        // The template's Values collection is empty, so cloning it skips the PropertyValue
+        // deep-clone entirely; the original value reference is attached, matching the
+        // pre-existing aliasing semantics of CopyPropertyWithValue.
+        private static Property CopyWithValue(this Property template, PropertyValue propertyValue)
+        {
+            var clonedProperty = template.CloneTyped();
             clonedProperty.Values = new List<PropertyValue> { propertyValue };
             return clonedProperty;
         }
 
         private static Property CopyPropertyWithoutValues(this Property property)
         {
-            var clonedProperty = (Property)property.Clone();
+            var clonedProperty = property.CloneTyped();
             clonedProperty.Values = Array.Empty<PropertyValue>();
             return clonedProperty;
         }

--- a/src/VirtoCommerce.XCatalog.Core/Models/ExpProduct.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Models/ExpProduct.cs
@@ -14,6 +14,7 @@ using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.Xapi.Core.Binding;
 using VirtoCommerce.Xapi.Core.Models;
 using VirtoCommerce.XCatalog.Core.Binding;
+using VirtoCommerce.XCatalog.Core.Extensions;
 using VirtoCommerce.XCatalog.Core.Specifications;
 using ProductPrice = VirtoCommerce.Xapi.Core.Models.ProductPrice;
 
@@ -109,6 +110,30 @@ namespace VirtoCommerce.XCatalog.Core.Models
                 return result;
             }
         }
+
+        /// <summary>
+        /// Returns the expanded property list for the given culture. The result is memoized on the instance:
+        /// field resolvers run once per GraphQL node while the instance is shared across nodes via a DataLoader,
+        /// so without memoization the expansion (which deep-clones a property per value) would run per node.
+        /// Callers must treat the returned list and its items as read-only.
+        /// </summary>
+        public virtual IList<Property> GetExpandedProperties(string cultureName)
+        {
+            var cached = _expandedProperties;
+            if (cached is null || !cached.CultureName.EqualsIgnoreCase(cultureName))
+            {
+                cached = new ExpandedProperties(cultureName, IndexedProduct?.Properties.ExpandOrderedByValues(cultureName) ?? new List<Property>());
+                _expandedProperties = cached;
+            }
+
+            return cached.Properties;
+        }
+
+        // Single-entry cache: a GraphQL request carries one culture, so one slot is enough; a concurrent
+        // resolver race or another culture just recomputes the same pure projection (last writer wins).
+        private volatile ExpandedProperties _expandedProperties;
+
+        private sealed record ExpandedProperties(string CultureName, IList<Property> Properties);
 
         public virtual void ApplyStaticDiscounts()
         {

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -336,7 +336,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             {
                 var names = context.GetArgument<string[]>("names");
                 var cultureName = context.GetValue<string>("cultureName");
-                var result = context.Source.IndexedProduct.Properties.ExpandOrderedByValues(cultureName);
+                var result = context.Source.GetExpandedProperties(cultureName);
                 if (!names.IsNullOrEmpty())
                 {
                     result = result.Where(x => names.Contains(x.Name, StringComparer.InvariantCultureIgnoreCase)).ToList();

--- a/tests/VirtoCommerce.XCatalog.Tests/Extensions/PropertyExtensionsTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Extensions/PropertyExtensionsTests.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.XCatalog.Core.Extensions;
+using Xunit;
+
+namespace VirtoCommerce.XCatalog.Tests.Extensions;
+
+public class PropertyExtensionsTests
+{
+    private const string CultureName = "en-US";
+
+    [Fact]
+    public void ExpandByValues_NonDictionary_WrapsEachMatchingValueIntoOwnProperty()
+    {
+        var value1 = new PropertyValue { Value = "Red", LanguageCode = CultureName };
+        var value2 = new PropertyValue { Value = "Blue", LanguageCode = CultureName };
+        var otherCulture = new PropertyValue { Value = "Rot", LanguageCode = "de-DE" };
+        var property = new Property { Name = "Color", Values = new List<PropertyValue> { value1, value2, otherCulture } };
+
+        var result = new[] { property }.ExpandByValues(CultureName);
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(x => x.Name == "Color");
+        result.Should().OnlyContain(x => !ReferenceEquals(x, property));
+        result[0].Values.Should().ContainSingle().Which.Should().BeSameAs(value1);
+        result[1].Values.Should().ContainSingle().Which.Should().BeSameAs(value2);
+        property.Values.Should().HaveCount(3, "the source property must not be mutated");
+    }
+
+    [Fact]
+    public void ExpandByValues_ExpandedCopiesHaveIndependentPropertyGraphs()
+    {
+        var property = new Property
+        {
+            Name = "Color",
+            Values = new List<PropertyValue>
+            {
+                new() { Value = "Red", LanguageCode = CultureName },
+                new() { Value = "Blue", LanguageCode = CultureName },
+            },
+            Attributes = new List<PropertyAttribute> { new() { Name = "attr", Value = "v" } },
+        };
+
+        var result = new[] { property }.ExpandByValues(CultureName);
+
+        result[0].Attributes.Should().NotBeSameAs(property.Attributes);
+        result[0].Attributes.Should().NotBeSameAs(result[1].Attributes);
+        result[0].Attributes.Single().Should().NotBeSameAs(property.Attributes.Single());
+    }
+
+    [Fact]
+    public void ExpandByValues_Dictionary_LocalizedValuePickedFallbackBuiltFromAlias()
+    {
+        var localized = new PropertyValue { Alias = "R", Value = "Red", LanguageCode = CultureName };
+        var foreignOnly = new PropertyValue { Alias = "B", Value = "Blau", LanguageCode = "de-DE" };
+        var property = new Property
+        {
+            Name = "Color",
+            Dictionary = true,
+            Values = new List<PropertyValue> { localized, foreignOnly },
+        };
+
+        var result = new[] { property }.ExpandByValues(CultureName);
+
+        result.Should().HaveCount(2);
+        result[0].Values.Should().ContainSingle().Which.Should().BeSameAs(localized);
+        var fallback = result[1].Values.Should().ContainSingle().Subject;
+        fallback.Should().NotBeSameAs(foreignOnly, "missing localization is replaced by a built default value");
+        fallback.Value.Should().Be("B");
+    }
+
+    [Fact]
+    public void ExpandByValues_NoMatchingValues_YieldsSinglePropertyWithEmptyValues()
+    {
+        var property = new Property
+        {
+            Name = "Color",
+            Values = new List<PropertyValue> { new() { Value = "Rot", LanguageCode = "de-DE" } },
+        };
+
+        var result = new[] { property }.ExpandByValues(CultureName);
+
+        result.Should().ContainSingle().Which.Values.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExpandByValues_HiddenPropertiesAreSkipped()
+    {
+        var property = new Property
+        {
+            Name = "Hidden",
+            Hidden = true,
+            Values = new List<PropertyValue> { new() { Value = "x", LanguageCode = CultureName } },
+        };
+
+        new[] { property }.ExpandByValues(CultureName).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CopyPropertyWithValue_ReturnsCloneCarryingTheOriginalValueReference()
+    {
+        var property = new Property
+        {
+            Name = "Color",
+            Values = new List<PropertyValue> { new() { Value = "Red", LanguageCode = CultureName } },
+        };
+        var value = new PropertyValue { Value = "Blue", LanguageCode = CultureName };
+
+        var copy = value.CopyPropertyWithValue(property);
+
+        copy.Should().NotBeSameAs(property);
+        copy.Name.Should().Be("Color");
+        copy.Values.Should().ContainSingle().Which.Should().BeSameAs(value);
+        property.Values.Should().ContainSingle("the source property must not be mutated");
+    }
+}

--- a/tests/VirtoCommerce.XCatalog.Tests/Models/ExpProductTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Models/ExpProductTests.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.XCatalog.Core.Extensions;
+using VirtoCommerce.XCatalog.Core.Models;
+using Xunit;
+
+namespace VirtoCommerce.XCatalog.Tests.Models;
+
+public class ExpProductTests
+{
+    private const string CultureName = "en-US";
+
+    [Fact]
+    public void GetExpandedProperties_SameCulture_ReturnsSameInstance()
+    {
+        var product = CreateProduct();
+
+        var first = product.GetExpandedProperties(CultureName);
+        var second = product.GetExpandedProperties(CultureName);
+
+        second.Should().BeSameAs(first);
+    }
+
+    [Fact]
+    public void GetExpandedProperties_MatchesDirectExpansion()
+    {
+        var product = CreateProduct();
+
+        var expanded = product.GetExpandedProperties(CultureName);
+        var direct = product.IndexedProduct.Properties.ExpandOrderedByValues(CultureName);
+
+        expanded.Should().BeEquivalentTo(direct, options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void GetExpandedProperties_DifferentCulture_Recomputes()
+    {
+        var product = CreateProduct();
+
+        var enUs = product.GetExpandedProperties(CultureName);
+        var deDe = product.GetExpandedProperties("de-DE");
+
+        deDe.Should().NotBeSameAs(enUs);
+        deDe.Should().BeEquivalentTo(
+            product.IndexedProduct.Properties.ExpandOrderedByValues("de-DE"),
+            options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void GetExpandedProperties_NoIndexedProduct_ReturnsEmpty()
+    {
+        var product = new ExpProduct();
+
+        product.GetExpandedProperties(CultureName).Should().BeEmpty();
+    }
+
+    private static ExpProduct CreateProduct()
+    {
+        return new ExpProduct
+        {
+            IndexedProduct = new CatalogProduct
+            {
+                Properties = new List<Property>
+                {
+                    new()
+                    {
+                        Name = "Color",
+                        Values = new List<PropertyValue>
+                        {
+                            new() { Value = "Red", LanguageCode = CultureName },
+                            new() { Value = "Blue", LanguageCode = CultureName },
+                        },
+                    },
+                    new()
+                    {
+                        Name = "Size",
+                        Values = new List<PropertyValue>
+                        {
+                            new() { Value = "L", LanguageCode = CultureName },
+                        },
+                    },
+                },
+            },
+        };
+    }
+}


### PR DESCRIPTION
## Problem

The `ProductType` `"properties"` field resolver pays two compounding costs on every resolution:

1. **O(values²) clone waste inside the expansion.** `ExpandByValues` wraps each `PropertyValue` into its own `Property` via `CopyPropertyWithValue`, which calls `Property.Clone()` — and `Property.Clone()` deep-clones **all** values of the property. The per-value copy then immediately discards those cloned values (`clonedProperty.Values = new List { propertyValue }`). For a property with V values that is V × V `PropertyValue` clones, all thrown away. This cost applies to **every** query shape — every distinct product on a PDP, search page, or cart pays it.

2. **Per-node re-expansion of the same product.** The DataLoader deduplicates the product *fetch* (N line items referencing the same product load one `ExpProduct`), but the resolver body still runs once per node — nodes referencing the same product re-run the identical expansion.

## Fix

Two complementary changes:

1. **Template clone** (`PropertyExtensions`): clone a values-free template once per property, then clone the template per value (its `Values` are empty, so no `PropertyValue` clones) and attach the original value reference — exactly the aliasing semantics the code already had. Output shape is unchanged (covered by new tests). Public `CopyPropertyWithValue` keeps its contract.

2. **Per-request memoization** (`ExpProduct.GetExpandedProperties(cultureName)`): single-slot volatile cache; `ExpProduct` instances are request-scoped (produced by product loads / DataLoaders), so there is no staleness; a concurrent race or another culture recomputes the same pure projection. The `names` argument filter already projects into a new list, so the cached list is never mutated.

`VariationType."properties"` (unordered `ExpandByValues`) benefits from the template clone automatically; `keyProperties` is untouched (separate helper, minor share).

## Measurements

**Realistic mix** — cart of 200 line items over 130 distinct products (duplication ≈1.5×), steady arrivals, identical knobs and capture windows, A = without this PR, B = with it:

| metric | A | B | delta |
|---|---|---|---|
| request latency avg / p95 | 19.8 s / 41.0 s | 13.6 s / 19.7 s | **−31% / −52%** |
| completed iterations (same window) | 1214 (3.5% failed) | 1776 (0% failed) | **+46%** |
| allocation per request (gc-verbose est.) | ~230 MB | ~142 MB | **−38%** |

(The absolute latencies are an overload-shaped stress band — arrivals exceeded capacity in both runs; deltas are the signal.) The remaining `Property.Clone` share in run B is dominated by the CRUD-layer defensive clone of cached products during product load — a separate concern, out of scope here.

**Max-duplication bound** — 200 line items of one product (best case for the memoization half): total allocation −31% for the window, `Property.Clone` leaf share 16.0% → 0.9%, latency avg 173 → 161 ms.

## Behavioural notes for reviewers

- Sibling nodes resolving the same product share one expanded `IList<Property>` (previously fresh clones per node). All in-tree consumers are read-only projections; an `ExtendableField` override that mutates a resolved `Property` in place would now affect sibling nodes. Value-instance sharing already existed in stock code (`CopyPropertyWithValue` attaches the original `PropertyValue` reference).
- Expanded copies still get their own `Attributes` / `DisplayNames` / `ValidationRules` clones — per-copy graph independence is preserved (covered by a test).

## Tests

- `PropertyExtensionsTests` (6 new): expansion output/order/aliasing invariants, dictionary-property grouping and fallback, hidden filtering, empty-values case, graph independence, `CopyPropertyWithValue` contract.
- `ExpProductTests` (4 new): memoization identity, equality with direct expansion, culture recompute, null product.
- Full suite: 114/114 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hot-path GraphQL behavior change: shared memoized property lists mean in-place mutation of resolved `Property` objects could affect other nodes; expansion output is test-locked but remains cloning-heavy logic.
> 
> **Overview**
> Cuts cost on the GraphQL **Product `properties`** path by changing how culture-expanded properties are built and by caching the result per `ExpProduct`.
> 
> **`ExpandByValues`** now clones a **values-empty property template once per source property**, then attaches each matching `PropertyValue` by reference instead of full-cloning the property (and all values) per value. Dictionary fallback cloning uses **`CloneTyped()`**; public **`CopyPropertyWithValue`** behavior is unchanged but routes through the new **`CopyWithValue`** helper.
> 
> **`ExpProduct.GetExpandedProperties(cultureName)`** memoizes **`ExpandOrderedByValues`** on the instance (single culture slot). **`ProductType`** resolves **`properties`** through this API so repeated nodes for the same product skip re-expansion; the optional **`names`** filter still projects to a new list.
> 
> New unit tests lock expansion shape, aliasing, dictionary/hidden/empty cases, and memoization semantics. Reviewers should treat expanded lists as **read-only**—sibling resolvers now share the same list instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61084ccb831044abe38c791fb892b5d8e45ff57b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5303
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.1014.0-pr-101-6108.zip