### PR TITLE
VCST-5089: Configure per-store Asset Public URL for XAPI asset links

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Schemas/AssetType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/AssetType.cs
@@ -1,6 +1,7 @@
 using GraphQL.Types;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.Xapi.Core.Schemas;
+using VirtoCommerce.Xapi.Core.Schemas.ScalarTypes;
 
 namespace VirtoCommerce.XCatalog.Core.Schemas
 {
@@ -14,7 +15,9 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             Field(x => x.Name, nullable: true).Description("The name of the asset.");
             Field(x => x.MimeType, nullable: true).Description("The MIME type of the asset.");
             Field(x => x.Size, nullable: false).Description("The size of the asset in bytes.");
-            Field(x => x.Url, nullable: false).Description("The URL of the asset.");
+            Field<NonNullGraphType<StoreUrlType>>("url")
+                .Description("The URL of the asset.")
+                .Resolve(context => context.Source.Url);
             Field(x => x.RelativeUrl, nullable: true).Description("The relative URL of the asset.");
             Field(x => x.TypeId, nullable: false).Description("The type ID of the asset.");
             Field(x => x.Group, nullable: true).Description("The group of the asset.");

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/BrandType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/BrandType.cs
@@ -7,6 +7,7 @@ using VirtoCommerce.Seo.Core.Models;
 using VirtoCommerce.StoreModule.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Schemas;
+using VirtoCommerce.Xapi.Core.Schemas.ScalarTypes;
 using VirtoCommerce.XCatalog.Core.Models;
 
 using SeoExtensions = VirtoCommerce.Seo.Core.Extensions.SeoExtensions;
@@ -80,14 +81,14 @@ public class BrandType : ExtendableGraphType<BrandAggregate>
 
         Field<NonNullGraphType<StringGraphType>>("permalink").Resolve(GetBrandPermalink);
 
-        Field<StringGraphType>("bannerUrl")
+        Field<StoreUrlType>("bannerUrl")
             .Resolve(context =>
             {
                 var result = context.Source.Images.FirstOrDefault(x => x.Group.EqualsIgnoreCase("Banner"))?.Url;
                 return result;
             });
 
-        Field<StringGraphType>("logoUrl")
+        Field<StoreUrlType>("logoUrl")
             .Resolve(context =>
             {
                 var result = context.Source.Images.FirstOrDefault(x => x.Group.EqualsIgnoreCase("Logo"))?.Url;

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/CategoryType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/CategoryType.cs
@@ -16,6 +16,7 @@ using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Helpers;
 using VirtoCommerce.Xapi.Core.Schemas;
+using VirtoCommerce.Xapi.Core.Schemas.ScalarTypes;
 using VirtoCommerce.XCatalog.Core.Extensions;
 using VirtoCommerce.XCatalog.Core.Models;
 using VirtoCommerce.XCatalog.Core.Queries;
@@ -31,7 +32,9 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             Name = "Category";
 
             Field(x => x.Id, nullable: false).Description("Id of category.");
-            Field(x => x.Category.ImgSrc, nullable: true).Description("The category image.");
+            Field<StoreUrlType>("imgSrc")
+                .Description("The category image.")
+                .Resolve(context => context.Source.Category.ImgSrc);
             Field(x => x.Category.Code, nullable: false).Description("SKU of category.");
             Field<NonNullGraphType<StringGraphType>>("name").Resolve(context =>
             {

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ImageType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ImageType.cs
@@ -1,6 +1,7 @@
 using GraphQL.Types;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.Xapi.Core.Schemas;
+using VirtoCommerce.Xapi.Core.Schemas.ScalarTypes;
 
 namespace VirtoCommerce.XCatalog.Core.Schemas
 {
@@ -35,7 +36,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             Field<StringGraphType>("group")
                 .Description("The group of the image")
                 .Resolve(context => context.Source.Group);
-            Field<NonNullGraphType<StringGraphType>>("url")
+            Field<NonNullGraphType<StoreUrlType>>("url")
                 .Description("The URL of the image")
                 .Resolve(context => context.Source.Url);
             Field<StringGraphType>("relativeUrl")

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -18,6 +18,7 @@ using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.Xapi.Core.Models;
 using VirtoCommerce.Xapi.Core.Schemas;
+using VirtoCommerce.Xapi.Core.Schemas.ScalarTypes;
 using VirtoCommerce.XCatalog.Core.Extensions;
 using VirtoCommerce.XCatalog.Core.Models;
 using VirtoCommerce.XCatalog.Core.Queries;
@@ -217,7 +218,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                     return response.Categories.FirstOrDefault();
                 });
 
-            Field<StringGraphType>("imgSrc")
+            Field<StoreUrlType>("imgSrc")
                 .Description("The product main image URL.")
                 .Resolve(context => context.Source.IndexedProduct.ImgSrc);
 

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>True</IsPackable>
@@ -12,6 +12,6 @@
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1014.0-alpha.185-vcst-5089" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1014.0-alpha.187-vcst-5089" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -12,6 +12,6 @@
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1014.0-alpha.187-vcst-5089" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1014.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -12,6 +12,6 @@
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1014.0-alpha.185-vcst-5089" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XCatalog.Data/Queries/GetBrandQueryBuilder.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/GetBrandQueryBuilder.cs
@@ -24,15 +24,4 @@ public class GetBrandQueryBuilder : QueryBuilder<GetBrandQuery, BrandAggregate, 
         context.CopyArgumentsToUserContext();
         return base.BeforeMediatorSend(context, request);
     }
-
-    protected override Task AfterMediatorSend(IResolveFieldContext<object> context, GetBrandQuery request, BrandAggregate response)
-    {
-        // Make the store available to StoreUrlType field resolution (banner/logo URLs).
-        if (response?.Store != null)
-        {
-            context.UserContext["store"] = response.Store;
-        }
-
-        return base.AfterMediatorSend(context, request, response);
-    }
 }

--- a/src/VirtoCommerce.XCatalog.Data/Queries/GetBrandQueryBuilder.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/GetBrandQueryBuilder.cs
@@ -24,4 +24,15 @@ public class GetBrandQueryBuilder : QueryBuilder<GetBrandQuery, BrandAggregate, 
         context.CopyArgumentsToUserContext();
         return base.BeforeMediatorSend(context, request);
     }
+
+    protected override Task AfterMediatorSend(IResolveFieldContext<object> context, GetBrandQuery request, BrandAggregate response)
+    {
+        // Make the store available to StoreUrlType field resolution (banner/logo URLs).
+        if (response?.Store != null)
+        {
+            context.UserContext["store"] = response.Store;
+        }
+
+        return base.AfterMediatorSend(context, request, response);
+    }
 }

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchBrandQueryBuilder.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchBrandQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using GraphQL;
 using MediatR;
@@ -23,5 +24,17 @@ public class SearchBrandQueryBuilder : SearchQueryBuilder<SearchBrandQuery, Sear
     {
         context.CopyArgumentsToUserContext();
         return base.BeforeMediatorSend(context, request);
+    }
+
+    protected override Task AfterMediatorSend(IResolveFieldContext<object> context, SearchBrandQuery request, SearchBrandResponse response)
+    {
+        // Make the store available to StoreUrlType field resolution (banner/logo URLs).
+        var store = response?.Results?.FirstOrDefault()?.Store;
+        if (store != null)
+        {
+            context.UserContext["store"] = store;
+        }
+
+        return base.AfterMediatorSend(context, request, response);
     }
 }

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -10,7 +10,7 @@
     <dependency id="VirtoCommerce.Inventory" version="3.1003.0" optional="true" />
     <dependency id="VirtoCommerce.Marketing" version="3.1005.0" optional="true" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" optional="true" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1014.0-alpha.185-vcst-5089" />
   </dependencies>
 
   <title>Catalog Experience API</title>

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -10,7 +10,7 @@
     <dependency id="VirtoCommerce.Inventory" version="3.1003.0" optional="true" />
     <dependency id="VirtoCommerce.Marketing" version="3.1005.0" optional="true" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" optional="true" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1014.0-alpha.185-vcst-5089" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1014.0-alpha.187-vcst-5089" />
   </dependencies>
 
   <title>Catalog Experience API</title>

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -10,7 +10,7 @@
     <dependency id="VirtoCommerce.Inventory" version="3.1003.0" optional="true" />
     <dependency id="VirtoCommerce.Marketing" version="3.1005.0" optional="true" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" optional="true" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1014.0-alpha.187-vcst-5089" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1014.0" />
   </dependencies>
 
   <title>Catalog Experience API</title>


### PR DESCRIPTION
## Description
feat: Configure per-store Asset Public URL for XAPI asset links

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5089
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.1013.0-pr-104-25ee.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how many high-traffic catalog URL fields are serialized in GraphQL; incorrect store context or scalar behavior could break storefront media links across products, categories, and brands.
> 
> **Overview**
> Catalog XAPI GraphQL responses now expose asset and media URLs through the **`StoreUrlType`** scalar from **VirtoCommerce.Xapi** `3.1014.0`, so links can be rewritten using each store’s **Asset Public URL** instead of returning raw strings.
> 
> **`url`** on assets and images, **`imgSrc`** on products and categories, and brand **`bannerUrl`** / **`logoUrl`** are switched from `StringGraphType` to `StoreUrlType` (with explicit resolvers where needed). The **`brands`** query builder sets **`context.UserContext["store"]`** after search so brand banner/logo resolution has store context when results are returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25ee95327d21a422ac7463f9a0b252107977b91a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->