### PR TITLE
VCST-5468: Resolve mediators per request

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Extensions/ProductAssociationExtension.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Extensions/ProductAssociationExtension.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Builders;
-using MediatR;
+using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.XCatalog.Core.Models;
@@ -15,7 +15,7 @@ namespace VirtoCommerce.XCatalog.Core.Extensions
         /// Resolves the GraphQL associations connection for any product-like source (a product or its variation),
         /// searching associations by the source item's own id. Shared by ProductType and VariationType.
         /// </summary>
-        public static async Task<object> ResolveAssociationsConnectionAsync<TSource>(this IResolveConnectionContext<TSource> context, IMediator mediator)
+        public static async Task<object> ResolveAssociationsConnectionAsync<TSource>(this IResolveConnectionContext<TSource> context)
             where TSource : ExpProduct
         {
             var first = context.First;
@@ -32,7 +32,7 @@ namespace VirtoCommerce.XCatalog.Core.Extensions
                 ObjectIds = [context.Source.IndexedProduct.Id]
             };
 
-            var response = await mediator.Send(query);
+            var response = await context.GetMediator().Send(query);
 
             return new PagedConnection<ProductAssociation>(response.Result.Results, query.Skip, query.Take, response.Result.TotalCount);
         }

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/CatalogDiscountType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/CatalogDiscountType.cs
@@ -26,7 +26,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 Arguments = new QueryArguments(),
                 Resolver = new FuncFieldResolver<Discount, IDataLoaderResult<Promotion>>(async context =>
                 {
-                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, Promotion>("promotionsLoader", ids => LoadPromotionsAsync(context, ids));
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, Promotion>("promotionsLoader", ids => LoadPromotionsAsync(ids, context));
                     var result = loader.LoadAsync(context.Source.PromotionId);
 
                     return await Task.FromResult(result);
@@ -42,7 +42,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
         {
         }
 
-        protected virtual async Task<IDictionary<string, Promotion>> LoadPromotionsAsync(IResolveFieldContext context, IEnumerable<string> ids)
+        protected virtual async Task<IDictionary<string, Promotion>> LoadPromotionsAsync(IEnumerable<string> ids, IResolveFieldContext context)
         {
             var result = await context.GetMediator().Send(new LoadPromotionsQuery { Ids = ids });
 

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/CatalogDiscountType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/CatalogDiscountType.cs
@@ -26,7 +26,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 Arguments = new QueryArguments(),
                 Resolver = new FuncFieldResolver<Discount, IDataLoaderResult<Promotion>>(async context =>
                 {
-                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, Promotion>("promotionsLoader", ids => LoadPromotionsAsync(context.GetMediator(), ids));
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, Promotion>("promotionsLoader", ids => LoadPromotionsAsync(ids, context));
                     var result = loader.LoadAsync(context.Source.PromotionId);
 
                     return await Task.FromResult(result);
@@ -42,9 +42,9 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
         {
         }
 
-        protected virtual async Task<IDictionary<string, Promotion>> LoadPromotionsAsync(IMediator mediator, IEnumerable<string> ids)
+        protected virtual async Task<IDictionary<string, Promotion>> LoadPromotionsAsync(IEnumerable<string> ids, IResolveFieldContext context)
         {
-            var result = await mediator.Send(new LoadPromotionsQuery { Ids = ids });
+            var result = await context.GetMediator().Send(new LoadPromotionsQuery { Ids = ids });
 
             return result.Promotions;
         }

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/CatalogDiscountType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/CatalogDiscountType.cs
@@ -26,7 +26,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 Arguments = new QueryArguments(),
                 Resolver = new FuncFieldResolver<Discount, IDataLoaderResult<Promotion>>(async context =>
                 {
-                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, Promotion>("promotionsLoader", ids => LoadPromotionsAsync(ids, context));
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, Promotion>("promotionsLoader", ids => LoadPromotionsAsync(context, ids));
                     var result = loader.LoadAsync(context.Source.PromotionId);
 
                     return await Task.FromResult(result);
@@ -42,7 +42,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
         {
         }
 
-        protected virtual async Task<IDictionary<string, Promotion>> LoadPromotionsAsync(IEnumerable<string> ids, IResolveFieldContext context)
+        protected virtual async Task<IDictionary<string, Promotion>> LoadPromotionsAsync(IResolveFieldContext context, IEnumerable<string> ids)
         {
             var result = await context.GetMediator().Send(new LoadPromotionsQuery { Ids = ids });
 

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/CatalogDiscountType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/CatalogDiscountType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL;
@@ -7,6 +8,7 @@ using GraphQL.Types;
 using MediatR;
 using VirtoCommerce.CoreModule.Core.Common;
 using VirtoCommerce.MarketingModule.Core.Model.Promotions;
+using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Helpers;
 using VirtoCommerce.Xapi.Core.Schemas;
 using VirtoCommerce.XCatalog.Core.Queries;
@@ -15,7 +17,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 {
     public class CatalogDiscountType : DiscountType
     {
-        public CatalogDiscountType(IMediator mediator, IDataLoaderContextAccessor dataLoader)
+        public CatalogDiscountType(IDataLoaderContextAccessor dataLoader)
         {
             var promotion = new FieldType
             {
@@ -24,7 +26,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 Arguments = new QueryArguments(),
                 Resolver = new FuncFieldResolver<Discount, IDataLoaderResult<Promotion>>(async context =>
                 {
-                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, Promotion>("promotionsLoader", (ids) => LoadPromotionsAsync(mediator, ids));
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, Promotion>("promotionsLoader", ids => LoadPromotionsAsync(context.GetMediator(), ids));
                     var result = loader.LoadAsync(context.Source.PromotionId);
 
                     return await Task.FromResult(result);
@@ -32,6 +34,12 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             };
 
             AddField(promotion);
+        }
+
+        [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+        public CatalogDiscountType(IMediator mediator, IDataLoaderContextAccessor dataLoader)
+            : this(dataLoader)
+        {
         }
 
         protected virtual async Task<IDictionary<string, Promotion>> LoadPromotionsAsync(IMediator mediator, IEnumerable<string> ids)

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/CategoryType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/CategoryType.cs
@@ -141,7 +141,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<CategoryType>(),
                 Resolver = new FuncFieldResolver<ExpCategory, IDataLoaderResult<ExpCategory>>(context =>
                 {
-                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("parentsCategoryLoader", ids => LoadCategoriesAsync(ids, context));
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("parentsCategoryLoader", ids => LoadCategoriesAsync(context, ids));
 
                     return TryGetCategoryParentId(context, out var parentCategoryId)
                         ? loader.LoadAsync(parentCategoryId)
@@ -229,7 +229,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             return false;
         }
 
-        private static async Task<IDictionary<string, ExpCategory>> LoadCategoriesAsync(IEnumerable<string> ids, IResolveFieldContext context)
+        private static async Task<IDictionary<string, ExpCategory>> LoadCategoriesAsync(IResolveFieldContext context, IEnumerable<string> ids)
         {
             var loadCategoryQuery = context.GetCatalogQuery<LoadCategoryQuery>();
             loadCategoryQuery.ObjectIds = ids.Where(x => x != null).ToArray();

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/CategoryType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/CategoryType.cs
@@ -141,7 +141,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<CategoryType>(),
                 Resolver = new FuncFieldResolver<ExpCategory, IDataLoaderResult<ExpCategory>>(context =>
                 {
-                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("parentsCategoryLoader", ids => LoadCategoriesAsync(context.GetMediator(), ids, context));
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("parentsCategoryLoader", ids => LoadCategoriesAsync(ids, context));
 
                     return TryGetCategoryParentId(context, out var parentCategoryId)
                         ? loader.LoadAsync(parentCategoryId)
@@ -229,13 +229,13 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             return false;
         }
 
-        private static async Task<IDictionary<string, ExpCategory>> LoadCategoriesAsync(IMediator mediator, IEnumerable<string> ids, IResolveFieldContext context)
+        private static async Task<IDictionary<string, ExpCategory>> LoadCategoriesAsync(IEnumerable<string> ids, IResolveFieldContext context)
         {
             var loadCategoryQuery = context.GetCatalogQuery<LoadCategoryQuery>();
             loadCategoryQuery.ObjectIds = ids.Where(x => x != null).ToArray();
             loadCategoryQuery.IncludeFields = context.SubFields.Values.GetAllNodesPaths(context).ToArray();
 
-            var response = await mediator.Send(loadCategoryQuery);
+            var response = await context.GetMediator().Send(loadCategoryQuery);
             return response.Categories.ToDictionary(x => x.Id);
         }
     }

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/CategoryType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/CategoryType.cs
@@ -27,7 +27,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 {
     public class CategoryType : ExtendableGraphType<ExpCategory>
     {
-        public CategoryType(IMediator mediator, IDataLoaderContextAccessor dataLoader)
+        public CategoryType(IDataLoaderContextAccessor dataLoader)
         {
             Name = "Category";
 
@@ -63,7 +63,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 var loadRelatedCatalogOutlineQuery = context.GetCatalogQuery<LoadRelatedCatalogOutlineQuery>();
                 loadRelatedCatalogOutlineQuery.Outlines = outlines;
 
-                var response = await mediator.Send(loadRelatedCatalogOutlineQuery);
+                var response = await context.GetMediator().Send(loadRelatedCatalogOutlineQuery);
                 return response.Outline;
             }).Description(@"All parent categories ids relative to the requested catalog and concatenated with \ . E.g. (1/21/344)");
 
@@ -78,7 +78,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 var loadRelatedSlugPathQuery = context.GetCatalogQuery<LoadRelatedSlugPathQuery>();
                 loadRelatedSlugPathQuery.Outlines = outlines;
 
-                var response = await mediator.Send(loadRelatedSlugPathQuery);
+                var response = await context.GetMediator().Send(loadRelatedSlugPathQuery);
                 return response.Slug;
             }).Description("Request related slug for category");
 
@@ -141,7 +141,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<CategoryType>(),
                 Resolver = new FuncFieldResolver<ExpCategory, IDataLoaderResult<ExpCategory>>(context =>
                 {
-                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("parentsCategoryLoader", ids => LoadCategoriesAsync(mediator, ids, context));
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("parentsCategoryLoader", ids => LoadCategoriesAsync(context.GetMediator(), ids, context));
 
                     return TryGetCategoryParentId(context, out var parentCategoryId)
                         ? loader.LoadAsync(parentCategoryId)
@@ -197,6 +197,12 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             ExtendableField<NonNullGraphType<ListGraphType<NonNullGraphType<CategoryType>>>>(
                 nameof(ExpCategory.ChildCategories),
                 resolve: context => context.Source.ChildCategories ?? Array.Empty<ExpCategory>());
+        }
+
+        [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+        public CategoryType(IMediator mediator, IDataLoaderContextAccessor dataLoader)
+            : this(dataLoader)
+        {
         }
 
         protected virtual bool TryGetCategoryParentId(IResolveFieldContext<ExpCategory> context, out string parentId)

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/CategoryType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/CategoryType.cs
@@ -141,7 +141,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<CategoryType>(),
                 Resolver = new FuncFieldResolver<ExpCategory, IDataLoaderResult<ExpCategory>>(context =>
                 {
-                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("parentsCategoryLoader", ids => LoadCategoriesAsync(context, ids));
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("parentsCategoryLoader", ids => LoadCategoriesAsync(ids, context));
 
                     return TryGetCategoryParentId(context, out var parentCategoryId)
                         ? loader.LoadAsync(parentCategoryId)
@@ -229,7 +229,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             return false;
         }
 
-        private static async Task<IDictionary<string, ExpCategory>> LoadCategoriesAsync(IResolveFieldContext context, IEnumerable<string> ids)
+        private static async Task<IDictionary<string, ExpCategory>> LoadCategoriesAsync(IEnumerable<string> ids, IResolveFieldContext context)
         {
             var loadCategoryQuery = context.GetCatalogQuery<LoadCategoryQuery>();
             loadCategoryQuery.ObjectIds = ids.Where(x => x != null).ToArray();

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductAssociationType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductAssociationType.cs
@@ -37,7 +37,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<ProductType>(),
                 Resolver = new FuncFieldResolver<ProductAssociation, IDataLoaderResult<ExpProduct>>(context =>
                 {
-                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("associatedProductLoader", ids => LoadProductsAsync(context.GetMediator(), ids, context));
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("associatedProductLoader", ids => LoadProductsAsync(ids, context));
                     return loader.LoadAsync(context.Source.AssociatedObjectId);
                 })
             };
@@ -50,13 +50,13 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
         {
         }
 
-        public static async Task<IDictionary<string, ExpProduct>> LoadProductsAsync(IMediator mediator, IEnumerable<string> ids, IResolveFieldContext context)
+        public static async Task<IDictionary<string, ExpProduct>> LoadProductsAsync(IEnumerable<string> ids, IResolveFieldContext context)
         {
             var query = context.GetCatalogQuery<LoadProductsQuery>();
             query.ObjectIds = ids.ToArray();
             query.IncludeFields = context.SubFields.Values.GetAllNodesPaths(context).Select(x => x.Replace("associations.items.product", string.Empty)).ToArray();
 
-            var response = await mediator.Send(query);
+            var response = await context.GetMediator().Send(query);
             return response.Products.ToDictionary(x => x.Id);
         }
     }

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductAssociationType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductAssociationType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -18,7 +19,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 {
     public class ProductAssociationType : ExtendableGraphType<ProductAssociation>
     {
-        public ProductAssociationType(IDataLoaderContextAccessor dataLoader, IMediator mediator)
+        public ProductAssociationType(IDataLoaderContextAccessor dataLoader)
         {
             Name = "ProductAssociation";
             Description = "product association.";
@@ -36,11 +37,17 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<ProductType>(),
                 Resolver = new FuncFieldResolver<ProductAssociation, IDataLoaderResult<ExpProduct>>(context =>
                 {
-                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("associatedProductLoader", (ids) => LoadProductsAsync(mediator, ids, context));
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("associatedProductLoader", ids => LoadProductsAsync(context.GetMediator(), ids, context));
                     return loader.LoadAsync(context.Source.AssociatedObjectId);
                 })
             };
             AddField(productField);
+        }
+
+        [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+        public ProductAssociationType(IDataLoaderContextAccessor dataLoader, IMediator mediator)
+            : this(dataLoader)
+        {
         }
 
         public static async Task<IDictionary<string, ExpProduct>> LoadProductsAsync(IMediator mediator, IEnumerable<string> ids, IResolveFieldContext context)

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductAssociationType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductAssociationType.cs
@@ -37,7 +37,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<ProductType>(),
                 Resolver = new FuncFieldResolver<ProductAssociation, IDataLoaderResult<ExpProduct>>(context =>
                 {
-                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("associatedProductLoader", ids => LoadProductsAsync(ids, context));
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("associatedProductLoader", ids => LoadProductsAsync(context, ids));
                     return loader.LoadAsync(context.Source.AssociatedObjectId);
                 })
             };
@@ -50,7 +50,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
         {
         }
 
-        public static async Task<IDictionary<string, ExpProduct>> LoadProductsAsync(IEnumerable<string> ids, IResolveFieldContext context)
+        public static async Task<IDictionary<string, ExpProduct>> LoadProductsAsync(IResolveFieldContext context, IEnumerable<string> ids)
         {
             var query = context.GetCatalogQuery<LoadProductsQuery>();
             query.ObjectIds = ids.ToArray();

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductAssociationType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductAssociationType.cs
@@ -37,7 +37,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<ProductType>(),
                 Resolver = new FuncFieldResolver<ProductAssociation, IDataLoaderResult<ExpProduct>>(context =>
                 {
-                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("associatedProductLoader", ids => LoadProductsAsync(context, ids));
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("associatedProductLoader", ids => LoadProductsAsync(ids, context));
                     return loader.LoadAsync(context.Source.AssociatedObjectId);
                 })
             };
@@ -50,7 +50,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
         {
         }
 
-        public static async Task<IDictionary<string, ExpProduct>> LoadProductsAsync(IResolveFieldContext context, IEnumerable<string> ids)
+        public static async Task<IDictionary<string, ExpProduct>> LoadProductsAsync(IEnumerable<string> ids, IResolveFieldContext context)
         {
             var query = context.GetCatalogQuery<LoadProductsQuery>();
             query.ObjectIds = ids.ToArray();

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -65,7 +65,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
         ///    }
         ///}
         /// </example>
-        public ProductType(IMediator mediator, IDataLoaderContextAccessor dataLoader)
+        public ProductType(IDataLoaderContextAccessor dataLoader)
         {
             Name = "Product";
             Description = "Products are the sellable goods in an e-commerce project.";
@@ -97,7 +97,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                             ProductIds = ids.ToArray()
                         };
 
-                        return await mediator.Send(query);
+                        return await context.GetMediator().Send(query);
                     });
                     return loader.LoadAsync(context.Source.Id);
                 })
@@ -116,7 +116,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 var loadRelatedCatalogOutlineQuery = context.GetCatalogQuery<LoadRelatedCatalogOutlineQuery>();
                 loadRelatedCatalogOutlineQuery.Outlines = outlines;
 
-                var response = await mediator.Send(loadRelatedCatalogOutlineQuery);
+                var response = await context.GetMediator().Send(loadRelatedCatalogOutlineQuery);
                 return response.Outline;
             }).Description(@"All parent categories ids relative to the requested catalog and concatenated with \ . E.g. (1/21/344)");
 
@@ -131,7 +131,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 var loadRelatedSlugPathQuery = context.GetCatalogQuery<LoadRelatedSlugPathQuery>();
                 loadRelatedSlugPathQuery.Outlines = outlines;
 
-                var response = await mediator.Send(loadRelatedSlugPathQuery);
+                var response = await context.GetMediator().Send(loadRelatedSlugPathQuery);
                 return response.Slug;
             }).Description("Request related slug for product");
 
@@ -213,7 +213,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                     loadCategoryQuery.ObjectIds = [categoryId];
                     loadCategoryQuery.IncludeFields = context.SubFields.Values.GetAllNodesPaths(context).ToArray();
 
-                    var response = await mediator.Send(loadCategoryQuery);
+                    var response = await context.GetMediator().Send(loadCategoryQuery);
 
                     return response.Categories.FirstOrDefault();
                 });
@@ -254,7 +254,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                         brandsQuery.BrandNames = brandNames.ToList();
                         brandsQuery.Take = brandsQuery.BrandNames.Count;
 
-                        var response = await mediator.Send(brandsQuery);
+                        var response = await context.GetMediator().Send(brandsQuery);
 
                         var result = response.Results.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
                         return result;
@@ -278,14 +278,14 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                     query.ObjectIds = new[] { context.Source.IndexedProduct.MainProductId };
                     query.IncludeFields = context.SubFields.Values.GetAllNodesPaths(context).ToArray();
 
-                    var response = await mediator.Send(query);
+                    var response = await context.GetMediator().Send(query);
 
                     return response.Products.Select(expProduct => new ExpVariation(expProduct)).FirstOrDefault();
                 });
 
             ExtendableFieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<VariationType>>>>(
                 "variations",
-                resolve: async context => await ResolveVariationsFieldAsync(mediator, context));
+                resolve: async context => await ResolveVariationsFieldAsync(context.GetMediator(), context));
 
             Field<NonNullGraphType<BooleanGraphType>, bool>("hasVariations")
                 .Resolve(context =>
@@ -401,12 +401,18 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
               .Argument<StringGraphType>("query", "the search phrase")
               .Argument<StringGraphType>("group", "association group (Accessories, RelatedItem)")
               .PageSize(Connections.DefaultPageSize)
-              .ResolveAsync(async context => await context.ResolveAssociationsConnectionAsync(mediator));
+              .ResolveAsync(async context => await context.ResolveAssociationsConnectionAsync(context.GetMediator()));
 
 
             Connection<VideoType>("videos")
               .PageSize(Connections.DefaultPageSize)
-              .ResolveAsync(async context => await ResolveVideosConnectionAsync(mediator, context));
+              .ResolveAsync(async context => await ResolveVideosConnectionAsync(context.GetMediator(), context));
+        }
+
+        [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+        public ProductType(IMediator mediator, IDataLoaderContextAccessor dataLoader)
+            : this(dataLoader)
+        {
         }
 
         private static string GetBrandName(IResolveFieldContext<ExpProduct> context)

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -401,7 +401,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
               .Argument<StringGraphType>("query", "the search phrase")
               .Argument<StringGraphType>("group", "association group (Accessories, RelatedItem)")
               .PageSize(Connections.DefaultPageSize)
-              .ResolveAsync(async context => await context.ResolveAssociationsConnectionAsync(context.GetMediator()));
+              .ResolveAsync(context => context.ResolveAssociationsConnectionAsync());
 
 
             Connection<VideoType>("videos")

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -285,7 +285,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             ExtendableFieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<VariationType>>>>(
                 "variations",
-                resolve: async context => await ResolveVariationsFieldAsync(context.GetMediator(), context));
+                resolve: ResolveVariationsFieldAsync);
 
             Field<NonNullGraphType<BooleanGraphType>, bool>("hasVariations")
                 .Resolve(context =>
@@ -406,7 +406,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             Connection<VideoType>("videos")
               .PageSize(Connections.DefaultPageSize)
-              .ResolveAsync(async context => await ResolveVideosConnectionAsync(context.GetMediator(), context));
+              .ResolveAsync(ResolveVideosConnectionAsync);
         }
 
         [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
@@ -426,7 +426,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             return brandName?.ToString();
         }
 
-        protected virtual async Task<object> ResolveVariationsFieldAsync(IMediator mediator, IResolveFieldContext<ExpProduct> context)
+        protected virtual async Task<object> ResolveVariationsFieldAsync(IResolveFieldContext<ExpProduct> context)
         {
             if (context.Source.IndexedVariationIds.IsNullOrEmpty())
             {
@@ -443,12 +443,12 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 query.IncludeFields.Add("isActive");
             }
 
-            var response = await mediator.Send(query);
+            var response = await context.GetMediator().Send(query);
 
             return response.Products.Where(x => x.IndexedProduct?.IsActive == true).Select(expProduct => new ExpVariation(expProduct));
         }
 
-        private static async Task<object> ResolveVideosConnectionAsync(IMediator mediator, IResolveConnectionContext<ExpProduct> context)
+        private static async Task<object> ResolveVideosConnectionAsync(IResolveConnectionContext<ExpProduct> context)
         {
             var first = context.First;
 
@@ -463,7 +463,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 CultureName = context.GetArgumentOrValue<string>("cultureName")
             };
 
-            var response = await mediator.Send(query);
+            var response = await context.GetMediator().Send(query);
 
             return new PagedConnection<Video>(response.Result.Results, query.Skip, query.Take, response.Result.TotalCount);
         }

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyType.cs
@@ -26,7 +26,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
     {
         private readonly IMeasureService _measureService;
 
-        public PropertyType(IMediator mediator, IDataLoaderContextAccessor dataLoader, IMeasureService measureService, IPropertyGroupService propertyGroupService)
+        public PropertyType(IDataLoaderContextAccessor dataLoader, IMeasureService measureService, IPropertyGroupService propertyGroupService)
         {
             _measureService = measureService;
 
@@ -104,7 +104,13 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             Connection<PropertyDictionaryItemType>("propertyDictionaryItems")
                 .PageSize(Connections.DefaultPageSize)
-                .ResolveAsync(context => ResolveConnectionAsync(mediator, context));
+                .ResolveAsync(context => ResolveConnectionAsync(context.GetMediator(), context));
+        }
+
+        [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+        public PropertyType(IMediator mediator, IDataLoaderContextAccessor dataLoader, IMeasureService measureService, IPropertyGroupService propertyGroupService)
+            : this(dataLoader, measureService, propertyGroupService)
+        {
         }
 
         protected virtual async Task<object> ResolveValue(Property source, string languageCode)

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/PropertyType.cs
@@ -104,7 +104,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             Connection<PropertyDictionaryItemType>("propertyDictionaryItems")
                 .PageSize(Connections.DefaultPageSize)
-                .ResolveAsync(context => ResolveConnectionAsync(context.GetMediator(), context));
+                .ResolveAsync(ResolveConnectionAsync);
         }
 
         [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
@@ -141,7 +141,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 : $"{decimalValue.FormatDecimal(languageCode)} {symbol}";
         }
 
-        private static async Task<object> ResolveConnectionAsync(IMediator mediator, IResolveConnectionContext<Property> context)
+        private static async Task<object> ResolveConnectionAsync(IResolveConnectionContext<Property> context)
         {
             var first = context.First;
 
@@ -154,7 +154,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 PropertyIds = [context.Source.Id],
             };
 
-            var response = await mediator.Send(query);
+            var response = await context.GetMediator().Send(query);
 
             return new PagedConnection<PropertyDictionaryItem>(response.Result.Results, query.Skip, query.Take, response.Result.TotalCount);
         }

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
@@ -111,7 +111,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
               .Argument<StringGraphType>("query", "the search phrase")
               .Argument<StringGraphType>("group", "association group (Accessories, RelatedItem)")
               .PageSize(Connections.DefaultPageSize)
-              .ResolveAsync(async context => await context.ResolveAssociationsConnectionAsync(context.GetMediator()));
+              .ResolveAsync(context => context.ResolveAssociationsConnectionAsync());
         }
 
         [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 {
     public class VariationType : ExtendableGraphType<ExpVariation>
     {
-        public VariationType(IMediator mediator)
+        public VariationType()
         {
             Field<NonNullGraphType<StringGraphType>>("id")
                 .Description("Id of variation.")
@@ -93,7 +93,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 var loadRelatedSlugPathQuery = context.GetCatalogQuery<LoadRelatedSlugPathQuery>();
                 loadRelatedSlugPathQuery.Outlines = outlines;
 
-                var response = await mediator.Send(loadRelatedSlugPathQuery);
+                var response = await context.GetMediator().Send(loadRelatedSlugPathQuery);
                 return response.Slug;
             }).Description("Request related slug for product");
 
@@ -111,7 +111,13 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
               .Argument<StringGraphType>("query", "the search phrase")
               .Argument<StringGraphType>("group", "association group (Accessories, RelatedItem)")
               .PageSize(Connections.DefaultPageSize)
-              .ResolveAsync(async context => await context.ResolveAssociationsConnectionAsync(mediator));
+              .ResolveAsync(async context => await context.ResolveAssociationsConnectionAsync(context.GetMediator()));
+        }
+
+        [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+        public VariationType(IMediator mediator)
+            : this()
+        {
         }
     }
 }

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -12,6 +12,6 @@
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1014.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XCatalog.Data/Queries/CatalogQueryBuilder.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/CatalogQueryBuilder.cs
@@ -23,14 +23,19 @@ public abstract class CatalogQueryBuilder<TQuery, TResult, TResultGraphType>
     private readonly ICurrencyService _currencyService;
 
     protected CatalogQueryBuilder(
-        IMediator mediator,
         IAuthorizationService authorizationService,
         IStoreService storeService,
         ICurrencyService currencyService)
-        : base(mediator, authorizationService)
+        : base(authorizationService)
     {
         _storeService = storeService;
         _currencyService = currencyService;
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    protected CatalogQueryBuilder(IMediator mediator, IAuthorizationService authorizationService, IStoreService storeService, ICurrencyService currencyService)
+        : this(authorizationService, storeService, currencyService)
+    {
     }
 
     protected override async Task BeforeMediatorSend(IResolveFieldContext<object> context, TQuery request)

--- a/src/VirtoCommerce.XCatalog.Data/Queries/ChildCategoriesQueryBuilder.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/ChildCategoriesQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,14 +26,19 @@ public class ChildCategoriesQueryBuilder : CatalogQueryBuilder<ChildCategoriesQu
     protected override string Name => "ChildCategories";
 
     public ChildCategoriesQueryBuilder(
-        IMediator mediator,
         IAuthorizationService authorizationService,
         IStoreService storeService,
         ICurrencyService currencyService,
         ICategoryService categoryService)
-        : base(mediator, authorizationService, storeService, currencyService)
+        : base(authorizationService, storeService, currencyService)
     {
         _categoryService = categoryService;
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public ChildCategoriesQueryBuilder(IMediator mediator, IAuthorizationService authorizationService, IStoreService storeService, ICurrencyService currencyService, ICategoryService categoryService)
+        : this(authorizationService, storeService, currencyService, categoryService)
+    {
     }
 
     protected override async Task BeforeMediatorSend(IResolveFieldContext<object> context, ChildCategoriesQuery request)

--- a/src/VirtoCommerce.XCatalog.Data/Queries/GetBrandQueryBuilder.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/GetBrandQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using MediatR;
@@ -14,8 +15,14 @@ public class GetBrandQueryBuilder : QueryBuilder<GetBrandQuery, BrandAggregate, 
 {
     protected override string Name => "brand";
 
+    public GetBrandQueryBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public GetBrandQueryBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 

--- a/src/VirtoCommerce.XCatalog.Data/Queries/ProductSuggestionsQueryBuilder.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/ProductSuggestionsQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using MediatR;
@@ -18,10 +19,16 @@ public class ProductSuggestionsQueryBuilder : QueryBuilder<ProductSuggestionsQue
 
     private readonly IStoreService _storeService;
 
-    public ProductSuggestionsQueryBuilder(IMediator mediator, IAuthorizationService authorizationService, IStoreService storeService)
-        : base(mediator, authorizationService)
+    public ProductSuggestionsQueryBuilder(IAuthorizationService authorizationService, IStoreService storeService)
+        : base(authorizationService)
     {
         _storeService = storeService;
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public ProductSuggestionsQueryBuilder(IMediator mediator, IAuthorizationService authorizationService, IStoreService storeService)
+        : this(authorizationService, storeService)
+    {
     }
 
     protected override async Task BeforeMediatorSend(IResolveFieldContext<object> context, ProductSuggestionsQuery request)

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchBrandQueryBuilder.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchBrandQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using GraphQL;
@@ -13,8 +14,14 @@ namespace VirtoCommerce.XCatalog.Data.Queries;
 
 public class SearchBrandQueryBuilder : SearchQueryBuilder<SearchBrandQuery, SearchBrandResponse, BrandAggregate, BrandType>
 {
+    public SearchBrandQueryBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public SearchBrandQueryBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryBuilder.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Types;
@@ -23,11 +24,16 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         protected virtual int DefaultPageSize => Connections.DefaultPageSize;
 
         public SearchProductQueryBuilder(
-            IMediator mediator,
             IAuthorizationService authorizationService,
             IStoreService storeService,
             ICurrencyService currencyService)
-            : base(mediator, authorizationService, storeService, currencyService)
+            : base(authorizationService, storeService, currencyService)
+        {
+        }
+
+        [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+        public SearchProductQueryBuilder(IMediator mediator, IAuthorizationService authorizationService, IStoreService storeService, ICurrencyService currencyService)
+            : this(authorizationService, storeService, currencyService)
         {
         }
 

--- a/src/VirtoCommerce.XCatalog.Data/Schemas/DigitalCatalogSchema.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Schemas/DigitalCatalogSchema.cs
@@ -93,7 +93,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                     var cultureName = context.GetArgument<string>("cultureName");
                     context.SetCurrencies(allCurrencies, cultureName);
 
-                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("productsLoader", ids => LoadProductsAsync(context.GetMediator(), ids, context));
+                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("productsLoader", ids => LoadProductsAsync(ids, context));
                     return loader.LoadAsync(context.GetArgument<string>("id"));
                 })
             };
@@ -122,7 +122,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                    // Authorize access to the store
                    await AuthorizeAsync(context, store);
 
-                   var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("categoriesLoader", ids => LoadCategoriesAsync(context.GetMediator(), ids, context));
+                   var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("categoriesLoader", ids => LoadCategoriesAsync(ids, context));
                    return loader.LoadAsync(context.GetArgument<string>("id"));
                })
             };
@@ -154,7 +154,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                 // Authorize access to the store
                 await AuthorizeAsync(context, store);
 
-                return await ResolveCategoriesConnectionAsync(context.GetMediator(), context);
+                return await ResolveCategoriesConnectionAsync(context);
             });
 
             schema.Query.AddField(categoriesConnectionBuilder.FieldType);
@@ -177,7 +177,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                 // Authorize access to the store
                 await AuthorizeAsync(context, store);
 
-                return await ResolvePropertiesConnectionAsync(context.GetMediator(), context);
+                return await ResolvePropertiesConnectionAsync(context);
             });
 
             schema.Query.AddField(propertiesConnectionBuilder.FieldType);
@@ -194,7 +194,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                 {
                     //PT-1606:  Need to check that there is no any alternative way to access to the original request arguments in sub selection
                     context.CopyArgumentsToUserContext();
-                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, Property>("propertiesLoader", ids => LoadPropertiesAsync(context.GetMediator(), ids));
+                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, Property>("propertiesLoader", ids => LoadPropertiesAsync(ids, context));
                     var result = loader.LoadAsync(context.GetArgument<string>("id"));
 
                     return await Task.FromResult(result);
@@ -203,36 +203,36 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
             schema.Query.AddField(propertyField);
         }
 
-        private static async Task<IDictionary<string, ExpProduct>> LoadProductsAsync(IMediator mediator, IEnumerable<string> ids, IResolveFieldContext context)
+        private static async Task<IDictionary<string, ExpProduct>> LoadProductsAsync(IEnumerable<string> ids, IResolveFieldContext context)
         {
             var query = context.GetCatalogQuery<LoadProductsQuery>();
             query.ObjectIds = ids.ToArray();
             query.IncludeFields = context.SubFields.Values.GetAllNodesPaths(context).ToArray();
 
-            var response = await mediator.Send(query);
+            var response = await context.GetMediator().Send(query);
 
             return response.Products.ToDictionary(x => x.Id);
         }
 
-        private static async Task<IDictionary<string, ExpCategory>> LoadCategoriesAsync(IMediator mediator, IEnumerable<string> ids, IResolveFieldContext context)
+        private static async Task<IDictionary<string, ExpCategory>> LoadCategoriesAsync(IEnumerable<string> ids, IResolveFieldContext context)
         {
             var query = context.GetCatalogQuery<LoadCategoryQuery>();
             query.ObjectIds = ids.ToArray();
             query.IncludeFields = context.SubFields.Values.GetAllNodesPaths(context).ToArray();
 
-            var response = await mediator.Send(query);
+            var response = await context.GetMediator().Send(query);
 
             return response.Categories.ToDictionary(x => x.Id);
         }
 
-        protected virtual async Task<IDictionary<string, Property>> LoadPropertiesAsync(IMediator mediator, IEnumerable<string> ids)
+        protected virtual async Task<IDictionary<string, Property>> LoadPropertiesAsync(IEnumerable<string> ids, IResolveFieldContext context)
         {
-            var result = await mediator.Send(new LoadPropertiesQuery { Ids = ids });
+            var result = await context.GetMediator().Send(new LoadPropertiesQuery { Ids = ids });
 
             return result.Properties;
         }
 
-        private static async Task<object> ResolveCategoriesConnectionAsync(IMediator mediator, IResolveConnectionContext<object> context)
+        private static async Task<object> ResolveCategoriesConnectionAsync(IResolveConnectionContext<object> context)
         {
             var first = context.First;
             var skip = Convert.ToInt32(context.After ?? 0.ToString());
@@ -260,12 +260,12 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                 query.Take = categoryIds.Count;
             }
 
-            var response = await mediator.Send(query);
+            var response = await context.GetMediator().Send(query);
 
             return new PagedConnection<ExpCategory>(response.Results, query.Skip, query.Take, response.TotalCount);
         }
 
-        private static async Task<object> ResolvePropertiesConnectionAsync(IMediator mediator, IResolveConnectionContext<object> context)
+        private static async Task<object> ResolvePropertiesConnectionAsync(IResolveConnectionContext<object> context)
         {
             var first = context.First;
 
@@ -281,7 +281,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                 Filter = context.GetArgument<string>("filter")
             };
 
-            var response = await mediator.Send(query);
+            var response = await context.GetMediator().Send(query);
 
             return new PagedConnection<Property>(response.Result.Results, query.Skip, query.Take, response.Result.TotalCount);
         }

--- a/src/VirtoCommerce.XCatalog.Data/Schemas/DigitalCatalogSchema.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Schemas/DigitalCatalogSchema.cs
@@ -93,7 +93,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                     var cultureName = context.GetArgument<string>("cultureName");
                     context.SetCurrencies(allCurrencies, cultureName);
 
-                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("productsLoader", ids => LoadProductsAsync(context, ids));
+                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("productsLoader", ids => LoadProductsAsync(ids, context));
                     return loader.LoadAsync(context.GetArgument<string>("id"));
                 })
             };
@@ -122,7 +122,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                    // Authorize access to the store
                    await AuthorizeAsync(context, store);
 
-                   var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("categoriesLoader", ids => LoadCategoriesAsync(context, ids));
+                   var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("categoriesLoader", ids => LoadCategoriesAsync(ids, context));
                    return loader.LoadAsync(context.GetArgument<string>("id"));
                })
             };
@@ -194,7 +194,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                 {
                     //PT-1606:  Need to check that there is no any alternative way to access to the original request arguments in sub selection
                     context.CopyArgumentsToUserContext();
-                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, Property>("propertiesLoader", ids => LoadPropertiesAsync(context, ids));
+                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, Property>("propertiesLoader", ids => LoadPropertiesAsync(ids, context));
                     var result = loader.LoadAsync(context.GetArgument<string>("id"));
 
                     return await Task.FromResult(result);
@@ -203,7 +203,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
             schema.Query.AddField(propertyField);
         }
 
-        private static async Task<IDictionary<string, ExpProduct>> LoadProductsAsync(IResolveFieldContext context, IEnumerable<string> ids)
+        private static async Task<IDictionary<string, ExpProduct>> LoadProductsAsync(IEnumerable<string> ids, IResolveFieldContext context)
         {
             var query = context.GetCatalogQuery<LoadProductsQuery>();
             query.ObjectIds = ids.ToArray();
@@ -214,7 +214,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
             return response.Products.ToDictionary(x => x.Id);
         }
 
-        private static async Task<IDictionary<string, ExpCategory>> LoadCategoriesAsync(IResolveFieldContext context, IEnumerable<string> ids)
+        private static async Task<IDictionary<string, ExpCategory>> LoadCategoriesAsync(IEnumerable<string> ids, IResolveFieldContext context)
         {
             var query = context.GetCatalogQuery<LoadCategoryQuery>();
             query.ObjectIds = ids.ToArray();
@@ -225,7 +225,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
             return response.Categories.ToDictionary(x => x.Id);
         }
 
-        protected virtual async Task<IDictionary<string, Property>> LoadPropertiesAsync(IResolveFieldContext context, IEnumerable<string> ids)
+        protected virtual async Task<IDictionary<string, Property>> LoadPropertiesAsync(IEnumerable<string> ids, IResolveFieldContext context)
         {
             var result = await context.GetMediator().Send(new LoadPropertiesQuery { Ids = ids });
 

--- a/src/VirtoCommerce.XCatalog.Data/Schemas/DigitalCatalogSchema.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Schemas/DigitalCatalogSchema.cs
@@ -30,24 +30,27 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
 {
     public class DigitalCatalogSchema : ISchemaBuilder
     {
-        private readonly IMediator _mediator;
         private readonly IDataLoaderContextAccessor _dataLoader;
         private readonly ICurrencyService _currencyService;
         private readonly IStoreService _storeService;
         private readonly IAuthorizationService _authorizationService;
 
         public DigitalCatalogSchema(
-            IMediator mediator,
             IDataLoaderContextAccessor dataLoader,
             ICurrencyService currencyService,
             IStoreService storeService,
             IAuthorizationService authorizationService)
         {
-            _mediator = mediator;
             _dataLoader = dataLoader;
             _currencyService = currencyService;
             _storeService = storeService;
             _authorizationService = authorizationService;
+        }
+
+        [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+        public DigitalCatalogSchema(IMediator mediator, IDataLoaderContextAccessor dataLoader, ICurrencyService currencyService, IStoreService storeService, IAuthorizationService authorizationService)
+            : this(dataLoader, currencyService, storeService, authorizationService)
+        {
         }
 
         /// <summary>
@@ -90,7 +93,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                     var cultureName = context.GetArgument<string>("cultureName");
                     context.SetCurrencies(allCurrencies, cultureName);
 
-                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("productsLoader", ids => LoadProductsAsync(_mediator, ids, context));
+                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("productsLoader", ids => LoadProductsAsync(context.GetMediator(), ids, context));
                     return loader.LoadAsync(context.GetArgument<string>("id"));
                 })
             };
@@ -119,7 +122,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                    // Authorize access to the store
                    await AuthorizeAsync(context, store);
 
-                   var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("categoriesLoader", ids => LoadCategoriesAsync(_mediator, ids, context));
+                   var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("categoriesLoader", ids => LoadCategoriesAsync(context.GetMediator(), ids, context));
                    return loader.LoadAsync(context.GetArgument<string>("id"));
                })
             };
@@ -151,7 +154,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                 // Authorize access to the store
                 await AuthorizeAsync(context, store);
 
-                return await ResolveCategoriesConnectionAsync(_mediator, context);
+                return await ResolveCategoriesConnectionAsync(context.GetMediator(), context);
             });
 
             schema.Query.AddField(categoriesConnectionBuilder.FieldType);
@@ -174,7 +177,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                 // Authorize access to the store
                 await AuthorizeAsync(context, store);
 
-                return await ResolvePropertiesConnectionAsync(_mediator, context);
+                return await ResolvePropertiesConnectionAsync(context.GetMediator(), context);
             });
 
             schema.Query.AddField(propertiesConnectionBuilder.FieldType);
@@ -191,7 +194,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                 {
                     //PT-1606:  Need to check that there is no any alternative way to access to the original request arguments in sub selection
                     context.CopyArgumentsToUserContext();
-                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, Property>("propertiesLoader", ids => LoadPropertiesAsync(_mediator, ids));
+                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, Property>("propertiesLoader", ids => LoadPropertiesAsync(context.GetMediator(), ids));
                     var result = loader.LoadAsync(context.GetArgument<string>("id"));
 
                     return await Task.FromResult(result);

--- a/src/VirtoCommerce.XCatalog.Data/Schemas/DigitalCatalogSchema.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Schemas/DigitalCatalogSchema.cs
@@ -93,7 +93,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                     var cultureName = context.GetArgument<string>("cultureName");
                     context.SetCurrencies(allCurrencies, cultureName);
 
-                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("productsLoader", ids => LoadProductsAsync(ids, context));
+                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>("productsLoader", ids => LoadProductsAsync(context, ids));
                     return loader.LoadAsync(context.GetArgument<string>("id"));
                 })
             };
@@ -122,7 +122,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                    // Authorize access to the store
                    await AuthorizeAsync(context, store);
 
-                   var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("categoriesLoader", ids => LoadCategoriesAsync(ids, context));
+                   var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpCategory>("categoriesLoader", ids => LoadCategoriesAsync(context, ids));
                    return loader.LoadAsync(context.GetArgument<string>("id"));
                })
             };
@@ -194,7 +194,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
                 {
                     //PT-1606:  Need to check that there is no any alternative way to access to the original request arguments in sub selection
                     context.CopyArgumentsToUserContext();
-                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, Property>("propertiesLoader", ids => LoadPropertiesAsync(ids, context));
+                    var loader = _dataLoader.Context.GetOrAddBatchLoader<string, Property>("propertiesLoader", ids => LoadPropertiesAsync(context, ids));
                     var result = loader.LoadAsync(context.GetArgument<string>("id"));
 
                     return await Task.FromResult(result);
@@ -203,7 +203,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
             schema.Query.AddField(propertyField);
         }
 
-        private static async Task<IDictionary<string, ExpProduct>> LoadProductsAsync(IEnumerable<string> ids, IResolveFieldContext context)
+        private static async Task<IDictionary<string, ExpProduct>> LoadProductsAsync(IResolveFieldContext context, IEnumerable<string> ids)
         {
             var query = context.GetCatalogQuery<LoadProductsQuery>();
             query.ObjectIds = ids.ToArray();
@@ -214,7 +214,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
             return response.Products.ToDictionary(x => x.Id);
         }
 
-        private static async Task<IDictionary<string, ExpCategory>> LoadCategoriesAsync(IEnumerable<string> ids, IResolveFieldContext context)
+        private static async Task<IDictionary<string, ExpCategory>> LoadCategoriesAsync(IResolveFieldContext context, IEnumerable<string> ids)
         {
             var query = context.GetCatalogQuery<LoadCategoryQuery>();
             query.ObjectIds = ids.ToArray();
@@ -225,7 +225,7 @@ namespace VirtoCommerce.XCatalog.Data.Schemas
             return response.Categories.ToDictionary(x => x.Id);
         }
 
-        protected virtual async Task<IDictionary<string, Property>> LoadPropertiesAsync(IEnumerable<string> ids, IResolveFieldContext context)
+        protected virtual async Task<IDictionary<string, Property>> LoadPropertiesAsync(IResolveFieldContext context, IEnumerable<string> ids)
         {
             var result = await context.GetMediator().Send(new LoadPropertiesQuery { Ids = ids });
 

--- a/src/VirtoCommerce.XCatalog.Data/Schemas/InventorySchema.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Schemas/InventorySchema.cs
@@ -19,11 +19,14 @@ namespace VirtoCommerce.XCatalog.Data.Schemas;
 
 public class InventorySchema : ISchemaBuilder
 {
-    private readonly IMediator _mediator;
-
-    public InventorySchema(IMediator mediator)
+    public InventorySchema()
     {
-        _mediator = mediator;
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public InventorySchema(IMediator mediator)
+        : this()
+    {
     }
 
     public void Build(ISchema schema)
@@ -47,7 +50,7 @@ public class InventorySchema : ISchemaBuilder
                     Id = id,
                     StoreId = storeId,
                 };
-                var fulfillmentCenter = await _mediator.Send(request);
+                var fulfillmentCenter = await context.GetMediator().Send(request);
 
                 if (fulfillmentCenter is not null)
                 {
@@ -66,11 +69,11 @@ public class InventorySchema : ISchemaBuilder
             .Argument<StringGraphType>("sort", "The sort expression")
             .Argument<ListGraphType<StringGraphType>>("fulfillmentCenterIds", "Filter by FFC IDs");
 
-        fulfillmentCentersConnectionBuilder.ResolveAsync(async context => await ResolveFulfillmentCentersConnectionAsync(_mediator, context));
+        fulfillmentCentersConnectionBuilder.ResolveAsync(ResolveFulfillmentCentersConnectionAsync);
         schema.Query.AddField(fulfillmentCentersConnectionBuilder.FieldType);
     }
 
-    private static async Task<object> ResolveFulfillmentCentersConnectionAsync(IMediator mediator, IResolveConnectionContext<object> context)
+    private static async Task<object> ResolveFulfillmentCentersConnectionAsync(IResolveConnectionContext<object> context)
     {
         context.CopyArgumentsToUserContext();
 
@@ -94,7 +97,7 @@ public class InventorySchema : ISchemaBuilder
             query.Take = fulfillmentCenterIds.Count;
         }
 
-        var response = await mediator.Send(query);
+        var response = await context.GetMediator().Send(query);
 
         return new PagedConnection<FulfillmentCenter>(response.Results, query.Skip, query.Take, response.TotalCount);
     }

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -10,7 +10,7 @@
     <dependency id="VirtoCommerce.Inventory" version="3.1003.0" optional="true" />
     <dependency id="VirtoCommerce.Marketing" version="3.1005.0" optional="true" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" optional="true" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1014.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1015.0" />
   </dependencies>
 
   <title>Catalog Experience API</title>

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeTests.cs
@@ -19,7 +19,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
 
         public ProductTypeTests()
         {
-            _productType = new ProductType(_mediatorMock.Object, _dataLoaderContextAccessorMock.Object);
+            _productType = new ProductType(_dataLoaderContextAccessorMock.Object);
         }
 
         #region Properties

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/PropertyTypeTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/PropertyTypeTests.cs
@@ -14,7 +14,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
 {
     public class PropertyTypeTests : XCatalogMoqHelper
     {
-        private readonly PropertyType _propertyType = new(null, null, null, null);
+        private readonly PropertyType _propertyType = new(null, null, null);
 
         [Fact]
         public async Task PropertyType_Properties_ShouldFilterPropertiesByCultureName()


### PR DESCRIPTION
## Description

GraphQL types, schemas, and query builders are created once while the schema is built. Injecting `IMediator` into their constructors captures the root service provider; requests can therefore resolve scoped handler dependencies from the wrong scope.

This change upgrades XApi to `3.1015.0` and resolves mediation through `context.GetMediator()` at field-resolution time across catalog graph types, DigitalCatalogSchema, InventorySchema, and catalog query builders.

Existing constructors that accept `IMediator` remain obsolete compatibility overloads and delegate to mediator-free constructors.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5468

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.1015.0-alpha.220-vcst-5468.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches most catalog GraphQL resolution paths; behavior should match prior logic but incorrect mediator scoping could have caused subtle production bugs, so regression testing on product/category queries and DataLoader batch paths is warranted.
> 
> **Overview**
> Fixes **scoped dependency misuse** in catalog GraphQL by stopping `IMediator` injection into types and builders that are created once at schema build time. Mediation now goes through **`context.GetMediator()`** during field resolution so handlers run with the current request’s `RequestServices`.
> 
> The change spans catalog **graph types** (`ProductType`, `CategoryType`, `VariationType`, etc.), **`DigitalCatalogSchema`** / **`InventorySchema`**, **query builders**, and **`ResolveAssociationsConnectionAsync`**. **`VirtoCommerce.Xapi.Core`** is bumped to **3.1015.0** (module manifest aligned).
> 
> Constructors that still take `IMediator` are kept as **`[Obsolete]`** overloads (diagnostic **VC0015**) delegating to mediator-free constructors; unit tests were updated to the new signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fba7807f1323263c8ed4b46d886e2e77b390065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->