### PR TITLE
VCST-5637: dedup identical product searches within one request

### DIFF
--- a/VirtoCommerce.XCatalog.sln
+++ b/VirtoCommerce.XCatalog.sln
@@ -14,6 +14,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{58249D0A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VirtoCommerce.XCatalog.Tests", "tests\VirtoCommerce.XCatalog.Tests\VirtoCommerce.XCatalog.Tests.csproj", "{10B2410F-EA36-4749-8AC1-78722513847E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{66320409-64EC-F7C5-3DEF-65E7510DAAD1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VirtoCommerce.XCatalog.Benchmark", "benchmarks\VirtoCommerce.XCatalog.Benchmark\VirtoCommerce.XCatalog.Benchmark.csproj", "{85A9F94A-ED81-462B-A788-0EEFA2A68AB7}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{681FC933-B87E-457E-80C9-E3EB12B19B51}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
@@ -48,6 +52,10 @@ Global
 		{10B2410F-EA36-4749-8AC1-78722513847E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{10B2410F-EA36-4749-8AC1-78722513847E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{10B2410F-EA36-4749-8AC1-78722513847E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85A9F94A-ED81-462B-A788-0EEFA2A68AB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85A9F94A-ED81-462B-A788-0EEFA2A68AB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85A9F94A-ED81-462B-A788-0EEFA2A68AB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{85A9F94A-ED81-462B-A788-0EEFA2A68AB7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -57,6 +65,7 @@ Global
 		{EE8C684B-B16E-45C3-8AF5-F9466EC3D0E0} = {0E35805D-33EB-4F07-BE87-9A39DADDD044}
 		{73AF2F73-02A8-4D4D-9FCD-1C944CFB0848} = {0E35805D-33EB-4F07-BE87-9A39DADDD044}
 		{10B2410F-EA36-4749-8AC1-78722513847E} = {58249D0A-2D27-4CCF-B173-E401846FA5D4}
+		{85A9F94A-ED81-462B-A788-0EEFA2A68AB7} = {66320409-64EC-F7C5-3DEF-65E7510DAAD1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {34CF91FB-2C99-4391-BB39-C484319B399A}

--- a/benchmarks/VirtoCommerce.XCatalog.Benchmark/Caching/SearchCacheKeyBenchmarks.cs
+++ b/benchmarks/VirtoCommerce.XCatalog.Benchmark/Caching/SearchCacheKeyBenchmarks.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using VirtoCommerce.SearchModule.Core.Model;
+using VirtoCommerce.XCatalog.Data.Index;
+using VirtoCommerce.XCatalog.Data.Queries;
+
+namespace VirtoCommerce.XCatalog.Benchmark.Caching;
+
+// What a request that searches ONCE pays for the deduplication it never uses: BuildSearchCacheKey
+// serializes the whole SearchRequest and hashes it, and that cost is charged on every call with no hit to
+// amortise it. The platform's JsonHashBenchmarks measure the hashing utility on a synthetic tree, because
+// Platform.Core cannot reference a search module; these measure the shipped method on a request built by
+// the same IndexSearchRequestBuilder the handler uses, which is the number a reviewer actually asked for.
+//
+// There is no baseline arm: the alternative to building a key is not building one, so the absolute figure
+// IS the overhead. Read it against an Elasticsearch round-trip (milliseconds) to judge the trade.
+
+/// <summary>
+/// Exposes the protected key builder. <c>GetType()</c> therefore reports this class rather than the
+/// handler, which changes the key's type segment but not what the measurement costs — the segment is
+/// rendered the same way either way. Dependencies are null because the method touches none of them.
+/// </summary>
+internal sealed class KeyBuilder : SearchProductQueryHandler
+{
+    public KeyBuilder()
+        : base(null, null, null, null, null, null, null, null, null, null)
+    {
+    }
+
+    public string Build(SearchRequest searchRequest) => BuildSearchCacheKey(searchRequest);
+}
+
+/// <summary>
+/// The by-ids load: the shape that actually deduplicates, since the same product set is re-requested by
+/// several resolvers within one GraphQL request. Carries no aggregations, which is why the response clone
+/// is free on this path and the key is the only cost the dedup adds.
+/// </summary>
+[MemoryDiagnoser]
+public class SearchCacheKeyByIdsBenchmarks
+{
+    private readonly KeyBuilder _keyBuilder = new();
+    private SearchRequest _request;
+
+    [Params(1, 20, 100)]
+    public int ObjectIdCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var ids = Enumerable.Range(0, ObjectIdCount).Select(i => $"product-{i:D8}").ToArray();
+
+        _request = new IndexSearchRequestBuilder()
+            .WithStoreId("B2B-store")
+            .WithIncludeFields("__object", "__prices", "__variations")
+            .AddObjectIds(ids)
+            .WithPaging(0, ObjectIdCount)
+            .Build();
+    }
+
+    [Benchmark]
+    public string BuildKey() => _keyBuilder.Build(_request);
+}
+
+/// <summary>
+/// The browse shape: keyword, catalog and validity-window filters, sorting and facets. It does not
+/// deduplicate as often, but it is the biggest request the key is taken over, so it brackets the cost from
+/// above.
+/// </summary>
+[MemoryDiagnoser]
+public class SearchCacheKeyBrowseBenchmarks
+{
+    private readonly KeyBuilder _keyBuilder = new();
+    private SearchRequest _request;
+
+    [Params(4, 16)]
+    public int FacetCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var builder = new IndexSearchRequestBuilder()
+            .WithStoreId("B2B-store")
+            .WithSearchPhrase("safety gloves")
+            .WithIncludeFields("__object", "__prices")
+            .AddTermFilter("__outline", "catalog-id/category-id")
+            .AddCertainDateFilter(new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc))
+            .AddSorting("priority:desc;name:asc")
+            .WithPaging(0, 20);
+
+        foreach (var i in Enumerable.Range(0, FacetCount))
+        {
+            builder.Aggregations.Add(new TermAggregationRequest
+            {
+                Id = $"facet-{i}",
+                FieldName = $"property-{i}",
+                Size = 10,
+                Values = [$"value-{i}-a", $"value-{i}-b"],
+            });
+        }
+
+        _request = builder.Build();
+    }
+
+    [Benchmark]
+    public string BuildKey() => _keyBuilder.Build(_request);
+}

--- a/benchmarks/VirtoCommerce.XCatalog.Benchmark/Caching/SearchCacheKeyBenchmarks.cs
+++ b/benchmarks/VirtoCommerce.XCatalog.Benchmark/Caching/SearchCacheKeyBenchmarks.cs
@@ -10,8 +10,18 @@ namespace VirtoCommerce.XCatalog.Benchmark.Caching;
 // What a request that searches ONCE pays for the deduplication it never uses: BuildSearchCacheKey
 // serializes the whole SearchRequest and hashes it, and that cost is charged on every call with no hit to
 // amortise it. The platform's JsonHashBenchmarks measure the hashing utility on a synthetic tree, because
-// Platform.Core cannot reference a search module; these measure the shipped method on a request built by
-// the same IndexSearchRequestBuilder the handler uses, which is the number a reviewer actually asked for.
+// Platform.Core cannot reference a search module; these measure the shipped method on a request built the
+// way GetIndexedSearchRequestBuilder builds it.
+//
+// The fixtures mirror that method's call chain rather than picking builder calls that look representative.
+// A thinner graph does not fail — it silently reports a smaller number, and the first version of this file
+// did exactly that: it omitted AddCertainDateFilter (unconditional in production, and the whole reason the
+// certain-date pinning exists) and ApplyMultiSelectFacetSearch (which clones the filter tree onto EVERY
+// aggregation), understating by 1.6x and 3-4.5x respectively.
+//
+// Two production steps are deliberately NOT reproduced, and both make these figures a floor rather than an
+// estimate: ParseFilters / ParseFacets need an ISearchPhraseParser and add user filters on top, and the
+// module pipeline (_pipeline.Execute(builder)) lets other modules extend the request before it is built.
 //
 // There is no baseline arm: the alternative to building a key is not building one, so the absolute figure
 // IS the overhead. Read it against an Elasticsearch round-trip (milliseconds) to judge the trade.
@@ -19,7 +29,8 @@ namespace VirtoCommerce.XCatalog.Benchmark.Caching;
 /// <summary>
 /// Exposes the protected key builder. <c>GetType()</c> therefore reports this class rather than the
 /// handler, which changes the key's type segment but not what the measurement costs — the segment is
-/// rendered the same way either way. Dependencies are null because the method touches none of them.
+/// rendered through a per-type cache either way. Dependencies are null because the method touches none of
+/// them, and the ten-argument base call binds to the current constructor, not to either obsolete overload.
 /// </summary>
 internal sealed class KeyBuilder : SearchProductQueryHandler
 {
@@ -31,10 +42,59 @@ internal sealed class KeyBuilder : SearchProductQueryHandler
     public string Build(SearchRequest searchRequest) => BuildSearchCacheKey(searchRequest);
 }
 
+internal static class RequestFixture
+{
+    // Production pins one instant per request; a fixed one here keeps the benchmark deterministic.
+    private static readonly DateTime _certainDate = new(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc);
+
+    // IndexFieldsMapper.MapToIndexIncludes turns the GraphQL selection into dotted leaf paths, so a
+    // realistic set is neither three literals nor the whole document.
+    private static readonly string[] _includeFields =
+    [
+        "__object.id", "__object.code", "__object.name", "__object.categoryId", "__object.outlines",
+        "__object.images", "__object.properties", "__prices.list", "__prices.sale", "__prices.currency",
+        "__variations.id", "__variations.code",
+    ];
+
+    /// <summary>
+    /// The calls <c>GetIndexedSearchRequestBuilder</c> makes on every request. A subsequence of its chain,
+    /// not a prefix: production interleaves <c>ParseFilters</c> and <c>WithSearchPhrase</c> between these,
+    /// and each arm appends its own. Order is immaterial to the built graph — every call here writes a
+    /// different part of the request — but do not read this as "nothing was interleaved".
+    /// </summary>
+    public static IndexSearchRequestBuilder Common()
+    {
+        return new IndexSearchRequestBuilder()
+            .WithStoreId("B2B-store")
+            .WithUserId("11111111-1111-1111-1111-111111111111")
+            .WithOrganizationId("22222222-2222-2222-2222-222222222222")
+            .WithCatalog("catalog-id")
+            .WithCurrency("USD")
+            .WithFuzzy(false)
+            .AddCertainDateFilter(_certainDate)
+            .WithMultilanguageProperties(["Brand", "Color"])
+            .WithCultureName("en-US")
+            .WithPreserveUserQuery(false)
+            .WithIncludeFields(_includeFields);
+    }
+
+    /// <summary>
+    /// What <c>AddDefaultTerms</c> adds — production applies it only when the request carries no object ids.
+    /// </summary>
+    public static IndexSearchRequestBuilder AddDefaultTerms(this IndexSearchRequestBuilder builder)
+    {
+        builder.AddTermFilter("is", "product", skipIfExists: true);
+        builder.AddTermFilter("status", "visible", skipIfExists: true);
+        builder.AddTermFilter("__outline", "catalog-id");
+
+        return builder;
+    }
+}
+
 /// <summary>
 /// The by-ids load: the shape that actually deduplicates, since the same product set is re-requested by
-/// several resolvers within one GraphQL request. Carries no aggregations, which is why the response clone
-/// is free on this path and the key is the only cost the dedup adds.
+/// several resolvers within one GraphQL request. Carries no aggregations — the response clone is free on
+/// this path, so the key is the only cost the deduplication adds.
 /// </summary>
 [MemoryDiagnoser]
 public class SearchCacheKeyByIdsBenchmarks
@@ -50,11 +110,10 @@ public class SearchCacheKeyByIdsBenchmarks
     {
         var ids = Enumerable.Range(0, ObjectIdCount).Select(i => $"product-{i:D8}").ToArray();
 
-        _request = new IndexSearchRequestBuilder()
-            .WithStoreId("B2B-store")
-            .WithIncludeFields("__object", "__prices", "__variations")
-            .AddObjectIds(ids)
+        // No default terms: production skips them when the request carries object ids.
+        _request = RequestFixture.Common()
             .WithPaging(0, ObjectIdCount)
+            .AddObjectIds(ids)
             .Build();
     }
 
@@ -63,9 +122,16 @@ public class SearchCacheKeyByIdsBenchmarks
 }
 
 /// <summary>
-/// The browse shape: keyword, catalog and validity-window filters, sorting and facets. It does not
-/// deduplicate as often, but it is the biggest request the key is taken over, so it brackets the cost from
-/// above.
+/// The browse shape: keyword, catalog and validity-window filters, sorting and facets. It deduplicates less
+/// often, but it is the largest request the key is taken over.
+/// <para>
+/// Specifically a catalog-ROOT browse: <c>AddDefaultTerms</c> contributes a single-segment
+/// <c>__outline</c>, for which production also leaves <c>CategoryId</c> null and emits one priority
+/// sorting field. A category browse is strictly larger — a longer outline value, which
+/// <c>ApplyMultiSelectFacetSearch</c> then clones into every aggregation, plus a fourth sorting field —
+/// and it reaches the request through <c>ParseFilters</c>, which this fixture does not reproduce. So the
+/// figures stay a floor in that direction too.
+/// </para>
 /// </summary>
 [MemoryDiagnoser]
 public class SearchCacheKeyBrowseBenchmarks
@@ -79,14 +145,11 @@ public class SearchCacheKeyBrowseBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        var builder = new IndexSearchRequestBuilder()
-            .WithStoreId("B2B-store")
+        var builder = RequestFixture.Common()
             .WithSearchPhrase("safety gloves")
-            .WithIncludeFields("__object", "__prices")
-            .AddTermFilter("__outline", "catalog-id/category-id")
-            .AddCertainDateFilter(new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc))
             .AddSorting("priority:desc;name:asc")
-            .WithPaging(0, 20);
+            .WithPaging(0, 20)
+            .AddDefaultTerms();
 
         foreach (var i in Enumerable.Range(0, FacetCount))
         {
@@ -99,7 +162,12 @@ public class SearchCacheKeyBrowseBenchmarks
             });
         }
 
-        _request = builder.Build();
+        // Load-bearing, and the omission the first version of this file shipped: production calls this
+        // immediately after ParseFacets, and it attaches a filtered CLONE of the whole request filter tree
+        // to every aggregation. Without it the hashed graph is 3-4.5x smaller than anything production has.
+        _request = builder
+            .ApplyMultiSelectFacetSearch()
+            .Build();
     }
 
     [Benchmark]

--- a/benchmarks/VirtoCommerce.XCatalog.Benchmark/Caching/SearchCacheKeyBenchmarks.cs
+++ b/benchmarks/VirtoCommerce.XCatalog.Benchmark/Caching/SearchCacheKeyBenchmarks.cs
@@ -8,20 +8,12 @@ using VirtoCommerce.XCatalog.Data.Queries;
 namespace VirtoCommerce.XCatalog.Benchmark.Caching;
 
 // What a request that searches ONCE pays for the deduplication it never uses: BuildSearchCacheKey
-// serializes the whole SearchRequest and hashes it, and that cost is charged on every call with no hit to
-// amortise it. The platform's JsonHashBenchmarks measure the hashing utility on a synthetic tree, because
-// Platform.Core cannot reference a search module; these measure the shipped method on a request built the
-// way GetIndexedSearchRequestBuilder builds it.
+// serializes the whole SearchRequest and hashes it on every call, with no hit to amortise it.
 //
-// The fixtures mirror that method's call chain rather than picking builder calls that look representative.
-// A thinner graph does not fail — it silently reports a smaller number, and the first version of this file
-// did exactly that: it omitted AddCertainDateFilter (unconditional in production, and the whole reason the
-// certain-date pinning exists) and ApplyMultiSelectFacetSearch (which clones the filter tree onto EVERY
-// aggregation), understating by 1.6x and 3-4.5x respectively.
-//
-// Two production steps are deliberately NOT reproduced, and both make these figures a floor rather than an
-// estimate: ParseFilters / ParseFacets need an ISearchPhraseParser and add user filters on top, and the
-// module pipeline (_pipeline.Execute(builder)) lets other modules extend the request before it is built.
+// The fixtures mirror GetIndexedSearchRequestBuilder's call chain rather than picking builder calls that
+// look representative, and that is load-bearing: a thinner graph does not fail, it silently reports a
+// smaller number. The first version of this file omitted two such calls and understated the result — the
+// README says which, by how much, and which production steps are deliberately not reproduced.
 //
 // There is no baseline arm: the alternative to building a key is not building one, so the absolute figure
 // IS the overhead. Read it against an Elasticsearch round-trip (milliseconds) to judge the trade.
@@ -162,9 +154,9 @@ public class SearchCacheKeyBrowseBenchmarks
             });
         }
 
-        // Load-bearing, and the omission the first version of this file shipped: production calls this
-        // immediately after ParseFacets, and it attaches a filtered CLONE of the whole request filter tree
-        // to every aggregation. Without it the hashed graph is 3-4.5x smaller than anything production has.
+        // Load-bearing, and one of the omissions the first version of this file shipped: production calls
+        // this immediately after ParseFacets, and it attaches a filtered CLONE of the whole request filter
+        // tree to every aggregation - so without it the hashed graph is far smaller than production's.
         _request = builder
             .ApplyMultiSelectFacetSearch()
             .Build();

--- a/benchmarks/VirtoCommerce.XCatalog.Benchmark/Program.cs
+++ b/benchmarks/VirtoCommerce.XCatalog.Benchmark/Program.cs
@@ -1,7 +1,4 @@
 using BenchmarkDotNet.Running;
 using VirtoCommerce.XCatalog.Benchmark.Caching;
 
-// Discovers every [Benchmark] class in this assembly. Select with --filter and choose a job with --job:
-//   dotnet run -c Release -- --filter '*SearchCacheKey*'
-//   dotnet run -c Release -- --filter '*' --job short
 BenchmarkSwitcher.FromAssembly(typeof(SearchCacheKeyByIdsBenchmarks).Assembly).Run(args);

--- a/benchmarks/VirtoCommerce.XCatalog.Benchmark/Program.cs
+++ b/benchmarks/VirtoCommerce.XCatalog.Benchmark/Program.cs
@@ -1,0 +1,7 @@
+using BenchmarkDotNet.Running;
+using VirtoCommerce.XCatalog.Benchmark.Caching;
+
+// Discovers every [Benchmark] class in this assembly. Select with --filter and choose a job with --job:
+//   dotnet run -c Release -- --filter '*SearchCacheKey*'
+//   dotnet run -c Release -- --filter '*' --job short
+BenchmarkSwitcher.FromAssembly(typeof(SearchCacheKeyByIdsBenchmarks).Assembly).Run(args);

--- a/benchmarks/VirtoCommerce.XCatalog.Benchmark/README.md
+++ b/benchmarks/VirtoCommerce.XCatalog.Benchmark/README.md
@@ -1,0 +1,64 @@
+# VirtoCommerce.XCatalog.Benchmark
+
+BenchmarkDotNet micro-benchmarks for `VirtoCommerce.XCatalog`. Mirrors the layout of
+`vc-platform/benchmarks/VirtoCommerce.Platform.Benchmark`.
+
+## Layout
+
+Each suite lives in its own subfolder with a matching `VirtoCommerce.XCatalog.Benchmark.<Suite>`
+namespace (`Caching/` today). To see what actually exists, ask the runner rather than a hand-maintained
+list:
+
+```bash
+cd benchmarks/VirtoCommerce.XCatalog.Benchmark
+dotnet run -c Release -- --list tree
+```
+
+## Prerequisites
+
+- .NET 10 SDK (or whichever TFM the project currently targets).
+
+## Running
+
+```bash
+cd benchmarks/VirtoCommerce.XCatalog.Benchmark
+
+dotnet run -c Release -- --filter '*'                    # everything
+dotnet run -c Release -- --filter '*SearchCacheKey*'     # the cache-key suite
+```
+
+Run from **this directory**. BenchmarkDotNet locates the project to rebuild relative to the working
+directory, so invoking it from elsewhere with `--project` fails with
+`Unable to find VirtoCommerce.XCatalog.Benchmark in <cwd>`.
+
+## Choosing a job
+
+`Allocated` (the `[MemoryDiagnoser]` column) is exact even on a cheap job, so for an allocation-focused
+check a quick job suffices; a trustworthy time `Mean` needs the full default job. On `--job short` the
+cache-key benchmarks reported a 99.9% margin of **65% of the mean** — usable for allocations, useless as
+a latency figure.
+
+```bash
+dotnet run -c Release -- --filter '*SearchCacheKey*' --job short   # byte-accurate alloc, cheap
+dotnet run -c Release -- --filter '*SearchCacheKey*'               # default job — trustworthy time Mean
+```
+
+## Caching / SearchCacheKeyBenchmarks
+
+Measures `SearchProductQueryHandler.BuildSearchCacheKey` — the serialize-and-hash a request pays on every
+product search, including one that searches only once and so never earns a cache hit.
+
+The fixtures mirror the call chain of `GetIndexedSearchRequestBuilder` rather than picking builder calls
+that look representative. That distinction is load-bearing: a thinner request graph does not fail, it
+silently reports a smaller number. The first version of this suite omitted `AddCertainDateFilter`
+(unconditional in production) and `ApplyMultiSelectFacetSearch` (which clones the filter tree onto every
+aggregation), understating by 1.6x and 3–4.5x.
+
+Two production steps are deliberately not reproduced, which makes these figures a **floor**:
+
+- `ParseFilters` / `ParseFacets` need an `ISearchPhraseParser` and add user-supplied filters on top.
+- The module pipeline (`_pipeline.Execute(builder)`) lets other modules extend the request before it is
+  built.
+
+When changing the key or the request shape, re-run and update the numbers quoted in the PR description —
+nothing verifies them.

--- a/benchmarks/VirtoCommerce.XCatalog.Benchmark/VirtoCommerce.XCatalog.Benchmark.csproj
+++ b/benchmarks/VirtoCommerce.XCatalog.Benchmark/VirtoCommerce.XCatalog.Benchmark.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <!-- Exploratory benchmark code; don't fail the build on warnings inherited from Directory.Build.props,
-         which sets TreatWarningsAsErrors. The obsolete-constructor overloads are deliberately exercised. -->
+         which sets TreatWarningsAsErrors solution-wide. -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <!-- Dev tooling, not a shipped package. -->
     <IsPackable>false</IsPackable>

--- a/benchmarks/VirtoCommerce.XCatalog.Benchmark/VirtoCommerce.XCatalog.Benchmark.csproj
+++ b/benchmarks/VirtoCommerce.XCatalog.Benchmark/VirtoCommerce.XCatalog.Benchmark.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <!-- Exploratory benchmark code; don't fail the build on warnings inherited from Directory.Build.props,
+         which sets TreatWarningsAsErrors. The obsolete-constructor overloads are deliberately exercised. -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <!-- Dev tooling, not a shipped package. -->
+    <IsPackable>false</IsPackable>
+    <!-- Exclude from SonarCloud: benchmark code legitimately uses magic params and static-field setup;
+         it is dev tooling, not production code subject to the quality gate. -->
+    <SonarQubeExclude>true</SonarQubeExclude>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\VirtoCommerce.XCatalog.Data\VirtoCommerce.XCatalog.Data.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/VirtoCommerce.XCatalog.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.XCatalog.Core/ModuleConstants.cs
@@ -4,12 +4,10 @@ namespace VirtoCommerce.XCatalog.Core
     {
         public const string KeyProperty = "KeyProperty";
 
-        // Key under which one request pins the instant its validity-window filters are evaluated at. The
-        // request-scoped cache is shared with every other consumer in the request, hence the prefix.
-        // Named for the purpose rather than for the handler so that a second validity-window consumer can
-        // share the instant: two searches in one response evaluated against different instants can only
-        // produce an inconsistent view. Today product search is the only consumer - category search does not
-        // filter by date at all, and the pricing middleware still reads its own clock.
+        // Prefixed because the request-scoped cache is shared with every consumer in the request, and named
+        // for the purpose rather than for the handler so a second validity-window consumer shares the instant
+        // instead of reading its own clock: two searches in one response evaluated against different instants
+        // can only produce an inconsistent view.
         public const string CertainDateRequestCacheKey = "xcatalog:search:certain-date";
 
         public const string DefaultBrandPropertyName = "Brand";

--- a/src/VirtoCommerce.XCatalog.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.XCatalog.Core/ModuleConstants.cs
@@ -4,6 +4,12 @@ namespace VirtoCommerce.XCatalog.Core
     {
         public const string KeyProperty = "KeyProperty";
 
+        // Key under which one request pins the instant its validity-window filters are evaluated at. The
+        // request-scoped cache is shared with every other consumer in the request, hence the prefix.
+        // Deliberately not per-handler: product and category search in one response must be filtered
+        // against the SAME instant, or a page can show a product as active and its category as not.
+        public const string CertainDateRequestCacheKey = "xcatalog:search:certain-date";
+
         public const string DefaultBrandPropertyName = "Brand";
         public const string BrandSeoType = "Brand";
         public const string BrandsSeoType = "Brands";

--- a/src/VirtoCommerce.XCatalog.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.XCatalog.Core/ModuleConstants.cs
@@ -6,8 +6,10 @@ namespace VirtoCommerce.XCatalog.Core
 
         // Key under which one request pins the instant its validity-window filters are evaluated at. The
         // request-scoped cache is shared with every other consumer in the request, hence the prefix.
-        // Deliberately not per-handler: product and category search in one response must be filtered
-        // against the SAME instant, or a page can show a product as active and its category as not.
+        // Named for the purpose rather than for the handler so that a second validity-window consumer can
+        // share the instant: two searches in one response evaluated against different instants can only
+        // produce an inconsistent view. Today product search is the only consumer - category search does not
+        // filter by date at all, and the pricing middleware still reads its own clock.
         public const string CertainDateRequestCacheKey = "xcatalog:search:certain-date";
 
         public const string DefaultBrandPropertyName = "Brand";

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1032.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1053.0-alpha.13351-vcst-5637-json-hash-extensions" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1032.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1053.0-alpha.13351-vcst-5637-json-hash-extensions" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1057.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.XCatalog.Data/Extensions/OverridableType.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Extensions/OverridableType.cs
@@ -1,9 +1,0 @@
-﻿using VirtoCommerce.Platform.Core.Common;
-
-namespace VirtoCommerce.XCatalog.Data.Extensions;
-
-internal static class OverridableType<T> where T : new()
-{
-    //TODO: Move to AbstractTypeFactory<T> when it will be implemented
-    public static T New() => AbstractTypeFactory<T>.HasOverrides ? AbstractTypeFactory<T>.TryCreateInstance() : new T();
-}

--- a/src/VirtoCommerce.XCatalog.Data/Index/IndexSearchRequestBuilder.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Index/IndexSearchRequestBuilder.cs
@@ -8,7 +8,6 @@ using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
 using VirtoCommerce.Xapi.Core.Index;
 using VirtoCommerce.XCatalog.Core.Extensions;
-using VirtoCommerce.XCatalog.Data.Extensions;
 
 namespace VirtoCommerce.XCatalog.Data.Index
 {
@@ -38,7 +37,7 @@ namespace VirtoCommerce.XCatalog.Data.Index
 
         public IndexSearchRequestBuilder()
         {
-            SearchRequest = OverridableType<SearchRequest>.New();
+            SearchRequest = AbstractTypeFactory<SearchRequest>.TryCreateInstance();
             SearchRequest.Filter = new AndFilter
             {
                 ChildFilters = new List<IFilter>(),

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchCategoryQueryHandler.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchCategoryQueryHandler.cs
@@ -17,7 +17,6 @@ using VirtoCommerce.Xapi.Core.Pipelines;
 using VirtoCommerce.XCatalog.Core.Extensions;
 using VirtoCommerce.XCatalog.Core.Models;
 using VirtoCommerce.XCatalog.Core.Queries;
-using VirtoCommerce.XCatalog.Data.Extensions;
 using VirtoCommerce.XCatalog.Data.Index;
 
 namespace VirtoCommerce.XCatalog.Data.Queries
@@ -88,7 +87,7 @@ namespace VirtoCommerce.XCatalog.Data.Queries
                 options.Items["cultureName"] = request.CultureName;
             })).ToList() ?? [];
 
-            var result = OverridableType<SearchCategoryResponse>.New();
+            var result = AbstractTypeFactory<SearchCategoryResponse>.TryCreateInstance();
             result.Query = request;
             result.Results = categories;
             result.Store = store;

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
@@ -308,15 +308,16 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         /// <c>ObjectIds</c> order is NOT canonicalised: it drives <c>IdsFilter.Values</c> and <c>Take</c>, so
         /// two orders are two different calls and hashing verbatim is correct.
         /// <br/><br/>
-        /// Scoped by the runtime type's FULL name, so a subclass that alters the search cannot collide with
-        /// the base handler's entries. <c>CacheKey.With(Type, ...)</c> alone would not give that: it renders
-        /// the type through <c>PrettyPrint</c>, which for a non-generic type yields the SHORT name, so a
-        /// subclass keeping the name <c>SearchProductQueryHandler</c> in its own namespace would key
-        /// identically to this one.
+        /// Scoped by <c>GetType()</c>, so a subclass that alters the search keys separately from the base
+        /// handler. Note the scoping is by the type's SHORT name - <c>CacheKey.With(Type, ...)</c> renders it
+        /// through <c>PrettyPrint</c> - so a subclass that kept the name <c>SearchProductQueryHandler</c> in
+        /// its own namespace would key identically. That is a property of the shared helper rather than of
+        /// this call site, and it is unreachable here anyway: the entry lives for one request, so it would
+        /// take two same-named handler types serving the same request to collide.
         /// </remarks>
         protected virtual string BuildSearchCacheKey(SearchRequest searchRequest)
         {
-            return CacheKey.With(GetType(), GetType().FullName, nameof(SearchProductsAsync), KnownDocumentTypes.Product, searchRequest.GetJsonSha256Hex());
+            return CacheKey.With(GetType(), nameof(SearchProductsAsync), KnownDocumentTypes.Product, searchRequest.GetJsonSha256Hex());
         }
 
         /// <summary>

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
@@ -78,8 +78,6 @@ namespace VirtoCommerce.XCatalog.Data.Queries
 
         // Both obsolete overloads target the primary constructor directly rather than chaining through each
         // other: a chain would route a caller of the oldest one through a member that is itself deprecated.
-        // The DiagnosticId names the release wave the deprecation belongs to, so it is shared with every
-        // other member deprecated in the same release - it is not allocated per site.
         [Obsolete("Use the constructor overload with IRequestScopedCacheAccessor to deduplicate identical searches within one request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
         public SearchProductQueryHandler(
             ISearchProvider searchProvider,
@@ -242,35 +240,18 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         /// re-entering through the former - go through one overridable call.
         /// </summary>
         /// <remarks>
-        /// An override replacing this with a caching implementation takes on four obligations, none of which
-        /// the compiler or a passing test will remind it about:
-        /// <br/><br/>
-        /// <b>Key completeness.</b> The response is a pure function of the two arguments
-        /// <see cref="ISearchProvider.SearchAsync"/> receives, so a key derived from the whole
-        /// <see cref="SearchRequest"/> is complete by construction. Enumerating selected fields instead is
-        /// how a key silently goes under-inclusive - note that entitlement reaches the provider only as
-        /// filters written into <see cref="SearchRequest.Filter"/>, not as anything the builder carries
-        /// alongside. Anything read from ambient state rather than from the request must be in the key too.
-        /// <br/><br/>
-        /// <b>Response isolation.</b> Callers mutate what they receive - the aggregation converter rewrites
-        /// ids on <c>AggregationResponseValue</c> in place, and <c>SetAppliedAggregations</c> writes back to
-        /// the request. A cached entry handed out twice unmodified therefore corrupts the second caller. Copy
-        /// on the way out, on <b>both</b> paths: a store-the-task cache hands the first caller the very
-        /// instance every later caller gets.
-        /// <br/><br/>
-        /// <b>Derived state.</b> The copy must carry whatever a derived response type adds. The default copy
-        /// below cannot do that for a type it does not know, and
-        /// <c>AbstractTypeFactory.TryCreateInstance</c> cannot either - it resolves by the base type's name
-        /// and copies no state. A derived type is the overrider's to preserve.
-        /// <br/><br/>
-        /// <b>Failure semantics.</b> A faulted search must not be retried for the rest of the request; the
-        /// request-scoped cache stores the faulted task and rethrows it, which is the intended behaviour.
-        /// <br/><br/>
-        /// One obligation the default copy below does NOT discharge, because it cannot: <c>Documents</c> is
-        /// shared by reference, and a <c>SearchDocument</c> is a mutable dictionary. Nothing on this path
-        /// writes to one - the binders only read, and each caller gets its own <c>ExpProduct</c> - but a
-        /// field binder that hands back a reference-typed value out of a document, which the caller then
-        /// mutates, corrupts every other holder of that cached entry. Treat documents as read-only.
+        /// <para>
+        /// An override that caches inherits three obligations the compiler and a passing test are both silent
+        /// about: the key must cover every input (see <see cref="BuildSearchCacheKey"/>), every caller must
+        /// get its own copy (see <see cref="CloneSearchResponse"/>), and a derived response type is the
+        /// overrider's to preserve - neither plain construction nor <c>AbstractTypeFactory</c> can.
+        /// </para>
+        /// <para>
+        /// <c>Documents</c> is shared by reference and a <c>SearchDocument</c> is a mutable dictionary.
+        /// Nothing on this path writes to one, so treat them as read-only: a field binder that hands a
+        /// reference-typed value out of a document to a caller that then mutates it corrupts every other
+        /// holder of that entry.
+        /// </para>
         /// </remarks>
         protected virtual Task<SearchResponse> SearchProductsAsync(SearchRequest searchRequest)
         {
@@ -304,16 +285,10 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         /// </summary>
         /// <remarks>
         /// The hash is over the request as a graph, not over selected fields - a hand-written projection goes
-        /// silently under-inclusive the day upstream adds a field, and serves the wrong documents. Note that
-        /// <c>ObjectIds</c> order is NOT canonicalised: it drives <c>IdsFilter.Values</c> and <c>Take</c>, so
-        /// two orders are two different calls and hashing verbatim is correct.
-        /// <br/><br/>
-        /// Scoped by <c>GetType()</c>, so a subclass that alters the search keys separately from the base
-        /// handler. Note the scoping is by the type's SHORT name - <c>CacheKey.With(Type, ...)</c> renders it
-        /// through <c>PrettyPrint</c> - so a subclass that kept the name <c>SearchProductQueryHandler</c> in
-        /// its own namespace would key identically. That is a property of the shared helper rather than of
-        /// this call site, and it is unreachable here anyway: the entry lives for one request, so it would
-        /// take two same-named handler types serving the same request to collide.
+        /// silently under-inclusive the day upstream adds a field, and serves the wrong documents.
+        /// <c>ObjectIds</c> order is deliberately NOT canonicalised: it drives <c>IdsFilter.Values</c> and
+        /// <c>Take</c>, so two orders are two different calls. <c>GetType()</c> scopes the key so a subclass
+        /// that alters the search keys separately from the base handler.
         /// </remarks>
         protected virtual string BuildSearchCacheKey(SearchRequest searchRequest)
         {
@@ -324,18 +299,19 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         /// A per-caller copy of a response that may be handed out more than once.
         /// </summary>
         /// <remarks>
-        /// Deep only where something downstream writes. <c>AggregationResponse.Id</c> and the ids on its
-        /// <c>Values</c> are both rewritten in place by the aggregation converter's range handling, so
-        /// sharing either would let one caller's conversion rewrite another's data - the values are the
-        /// half that is easy to miss, because copying only the <c>AggregationResponse</c> looks complete.
-        /// <c>Documents</c> and <c>Statistics</c> are shared deliberately: nothing on this path writes to
-        /// them, and documents are the large part of a response.
-        /// <br/><br/>
-        /// Deliberately <c>new SearchResponse()</c> rather than <c>AbstractTypeFactory</c>: that factory
-        /// resolves by the base type's NAME, so it would return the registered override type for a source
-        /// that is a plain base instance, and it copies no state either way. Neither plain construction nor
-        /// the factory can preserve a derived type - hence this is <c>virtual</c>, and preserving derived
-        /// state is stated as the overrider's obligation on <see cref="SearchProductsAsync"/>.
+        /// <para>
+        /// Deep only where something downstream writes, and the aggregation converter writes at both levels:
+        /// it replaces <c>AggregationResponse.Values</c> in place when it filters outlines, and mutates
+        /// <c>AggregationResponseValue.Id</c> in place in its range handling. The second is the one that is
+        /// easy to miss, because copying only the <c>AggregationResponse</c> looks complete.
+        /// <c>Documents</c> is shared deliberately - nothing on this path writes to one, and documents are
+        /// the large part of a response.
+        /// </para>
+        /// <para>
+        /// <c>new SearchResponse()</c> rather than <c>AbstractTypeFactory</c>: the factory resolves by the
+        /// base type's NAME, so it would return the registered override type for a source that is a plain base
+        /// instance, and it copies no state either way.
+        /// </para>
         /// </remarks>
         protected virtual SearchResponse CloneSearchResponse(SearchResponse source)
         {

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
@@ -265,6 +265,12 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         /// <br/><br/>
         /// <b>Failure semantics.</b> A faulted search must not be retried for the rest of the request; the
         /// request-scoped cache stores the faulted task and rethrows it, which is the intended behaviour.
+        /// <br/><br/>
+        /// One obligation the default copy below does NOT discharge, because it cannot: <c>Documents</c> is
+        /// shared by reference, and a <c>SearchDocument</c> is a mutable dictionary. Nothing on this path
+        /// writes to one - the binders only read, and each caller gets its own <c>ExpProduct</c> - but a
+        /// field binder that hands back a reference-typed value out of a document, which the caller then
+        /// mutates, corrupts every other holder of that cached entry. Treat documents as read-only.
         /// </remarks>
         protected virtual Task<SearchResponse> SearchProductsAsync(SearchRequest searchRequest)
         {
@@ -302,12 +308,15 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         /// <c>ObjectIds</c> order is NOT canonicalised: it drives <c>IdsFilter.Values</c> and <c>Take</c>, so
         /// two orders are two different calls and hashing verbatim is correct.
         /// <br/><br/>
-        /// Keyed on <c>GetType()</c> rather than this class, so a subclass that alters the search cannot
-        /// collide with the base handler's entries.
+        /// Scoped by the runtime type's FULL name, so a subclass that alters the search cannot collide with
+        /// the base handler's entries. <c>CacheKey.With(Type, ...)</c> alone would not give that: it renders
+        /// the type through <c>PrettyPrint</c>, which for a non-generic type yields the SHORT name, so a
+        /// subclass keeping the name <c>SearchProductQueryHandler</c> in its own namespace would key
+        /// identically to this one.
         /// </remarks>
         protected virtual string BuildSearchCacheKey(SearchRequest searchRequest)
         {
-            return CacheKey.With(GetType(), nameof(SearchProductsAsync), KnownDocumentTypes.Product, searchRequest.GetJsonSha256Hex());
+            return CacheKey.With(GetType(), GetType().FullName, nameof(SearchProductsAsync), KnownDocumentTypes.Product, searchRequest.GetJsonSha256Hex());
         }
 
         /// <summary>

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
@@ -239,10 +239,11 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         /// </summary>
         /// <remarks>
         /// <para>
-        /// An override that caches inherits three obligations the compiler and a passing test are both silent
-        /// about: the key must cover every input (see <see cref="BuildSearchCacheKey"/>), every caller must
-        /// get its own copy (see <see cref="CloneSearchResponse"/>), and a derived response type is the
-        /// overrider's to preserve - neither plain construction nor <c>AbstractTypeFactory</c> can.
+        /// An override that caches inherits two obligations the compiler and a passing test are both silent
+        /// about: the key must cover every input (see <see cref="BuildSearchCacheKey"/>), and every caller must
+        /// get its own copy (see <see cref="CloneSearchResponse"/>). The clone chain constructs through
+        /// <c>AbstractTypeFactory</c>, so a registered override type already comes back from it - what the base
+        /// cannot copy is the state that type adds.
         /// </para>
         /// <para>
         /// <c>Documents</c> is shared by reference and a <c>SearchDocument</c> is a mutable dictionary.
@@ -305,20 +306,16 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         /// <c>Documents</c> is shared deliberately - nothing on this path writes to one, and documents are
         /// the large part of a response.
         /// </para>
-        /// <para>
-        /// <c>new SearchResponse()</c> rather than <c>AbstractTypeFactory</c>: the factory resolves by the
-        /// base type's NAME, so it would return the registered override type for a source that is a plain base
-        /// instance, and it copies no state either way.
-        /// </para>
         /// </remarks>
         protected virtual SearchResponse CloneSearchResponse(SearchResponse source)
         {
-            return new SearchResponse
-            {
-                TotalCount = source.TotalCount,
-                Documents = source.Documents,
-                Aggregations = source.Aggregations?.Select(CloneAggregationResponse).ToList(),
-            };
+            var clone = OverridableType<SearchResponse>.New();
+
+            clone.TotalCount = source.TotalCount;
+            clone.Documents = source.Documents;
+            clone.Aggregations = source.Aggregations?.Select(CloneAggregationResponse).ToList();
+
+            return clone;
         }
 
         /// <summary>
@@ -327,12 +324,26 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         /// </summary>
         protected virtual AggregationResponse CloneAggregationResponse(AggregationResponse source)
         {
-            return new AggregationResponse
-            {
-                Id = source.Id,
-                Statistics = source.Statistics,
-                Values = source.Values?.Select(x => new AggregationResponseValue { Id = x.Id, Count = x.Count }).ToList(),
-            };
+            var clone = OverridableType<AggregationResponse>.New();
+
+            clone.Id = source.Id;
+            clone.Statistics = source.Statistics;
+            clone.Values = source.Values?.Select(CloneAggregationResponseValue).ToList();
+
+            return clone;
+        }
+
+        /// <summary>
+        /// Copy of one aggregation value - the level the converter's range handling mutates in place.
+        /// </summary>
+        protected virtual AggregationResponseValue CloneAggregationResponseValue(AggregationResponseValue source)
+        {
+            var clone = OverridableType<AggregationResponseValue>.New();
+
+            clone.Id = source.Id;
+            clone.Count = source.Count;
+
+            return clone;
         }
 
         // A cache keyed on a request that embeds a clock reading can never hit. AddCertainDateFilter writes

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
@@ -76,8 +76,6 @@ namespace VirtoCommerce.XCatalog.Data.Queries
             _requestScopedCacheAccessor = requestScopedCacheAccessor;
         }
 
-        // Both obsolete overloads target the primary constructor directly rather than chaining through each
-        // other: a chain would route a caller of the oldest one through a member that is itself deprecated.
         [Obsolete("Use the constructor overload with IRequestScopedCacheAccessor to deduplicate identical searches within one request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
         public SearchProductQueryHandler(
             ISearchProvider searchProvider,
@@ -264,10 +262,10 @@ namespace VirtoCommerce.XCatalog.Data.Queries
                 return _searchProvider.SearchAsync(KnownDocumentTypes.Product, searchRequest);
             }
 
-            return SearchProductsThroughCacheAsync(cache, searchRequest);
+            return SearchProductsCachedAsync(cache, searchRequest);
         }
 
-        private async Task<SearchResponse> SearchProductsThroughCacheAsync(IRequestScopedCache cache, SearchRequest searchRequest)
+        private async Task<SearchResponse> SearchProductsCachedAsync(IRequestScopedCache cache, SearchRequest searchRequest)
         {
             var response = await cache.GetOrAddAsync(
                 BuildSearchCacheKey(searchRequest),

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
@@ -317,10 +317,6 @@ namespace VirtoCommerce.XCatalog.Data.Queries
             return clone;
         }
 
-        /// <summary>
-        /// Copy of one aggregation, deep through its values. <c>Values</c> has no initializer, so null is
-        /// its default and a real response can carry it.
-        /// </summary>
         protected virtual AggregationResponse CloneAggregationResponse(AggregationResponse source)
         {
             var clone = AbstractTypeFactory<AggregationResponse>.TryCreateInstance();
@@ -332,9 +328,6 @@ namespace VirtoCommerce.XCatalog.Data.Queries
             return clone;
         }
 
-        /// <summary>
-        /// Copy of one aggregation value - the level the converter's range handling mutates in place.
-        /// </summary>
         protected virtual AggregationResponseValue CloneAggregationResponseValue(AggregationResponseValue source)
         {
             var clone = AbstractTypeFactory<AggregationResponseValue>.TryCreateInstance();

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
@@ -8,6 +8,7 @@ using VirtoCommerce.CatalogModule.Core.Model.Search;
 using VirtoCommerce.CatalogModule.Core.Search;
 using VirtoCommerce.CatalogModule.Core.Search.Sorting;
 using VirtoCommerce.CatalogModule.Core.Services;
+using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
@@ -16,6 +17,7 @@ using VirtoCommerce.StoreModule.Core.Services;
 using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.Xapi.Core.Models.Facets;
 using VirtoCommerce.Xapi.Core.Pipelines;
+using VirtoCommerce.XCatalog.Core;
 using VirtoCommerce.XCatalog.Core.Extensions;
 using VirtoCommerce.XCatalog.Core.Models;
 using VirtoCommerce.XCatalog.Core.Queries;
@@ -40,10 +42,15 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         private readonly ISearchPhraseParser _phraseParser;
         private readonly IProductSortingService _productSortingService;
         private readonly IPropertyService _propertyService;
+        private readonly IRequestScopedCacheAccessor _requestScopedCacheAccessor;
 
         // Set in Handle() before GetIndexedSearchRequestBuilder() is called; read by that method's own
         // WithMultilanguageProperties() call. Keeps the method's signature stable for existing overrides.
         protected IEnumerable<string> MultilanguagePropertyNames { get; set; } = [];
+
+        // Same arrangement, for the instant the validity-window filters are evaluated at. Null means "no
+        // request pinned one", which reads as UtcNow at the point of use.
+        protected DateTime? CertainDate { get; set; }
 
         public SearchProductQueryHandler(
             ISearchProvider searchProvider,
@@ -54,7 +61,8 @@ namespace VirtoCommerce.XCatalog.Data.Queries
             IAggregationConverter aggregationConverter,
             ISearchPhraseParser phraseParser,
             IProductSortingService productSortingService,
-            IPropertyService propertyService)
+            IPropertyService propertyService,
+            IRequestScopedCacheAccessor requestScopedCacheAccessor)
         {
             _searchProvider = searchProvider;
             _mapper = mapper;
@@ -65,6 +73,26 @@ namespace VirtoCommerce.XCatalog.Data.Queries
             _phraseParser = phraseParser;
             _productSortingService = productSortingService;
             _propertyService = propertyService;
+            _requestScopedCacheAccessor = requestScopedCacheAccessor;
+        }
+
+        // Both obsolete overloads target the primary constructor directly rather than chaining through each
+        // other: a chain would route a caller of the oldest one through a member that is itself deprecated.
+        // The DiagnosticId names the release wave the deprecation belongs to, so it is shared with every
+        // other member deprecated in the same release - it is not allocated per site.
+        [Obsolete("Use the constructor overload with IRequestScopedCacheAccessor to deduplicate identical searches within one request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+        public SearchProductQueryHandler(
+            ISearchProvider searchProvider,
+            IMapper mapper,
+            IStoreCurrencyResolver storeCurrencyResolver,
+            IStoreService storeService,
+            IGenericPipelineLauncher pipeline,
+            IAggregationConverter aggregationConverter,
+            ISearchPhraseParser phraseParser,
+            IProductSortingService productSortingService,
+            IPropertyService propertyService)
+            : this(searchProvider, mapper, storeCurrencyResolver, storeService, pipeline, aggregationConverter, phraseParser, productSortingService, propertyService, null)
+        {
         }
 
         [Obsolete("Use the constructor overload with IPropertyService to enable multilanguage property filtering.", DiagnosticId = "VC0016", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
@@ -77,7 +105,7 @@ namespace VirtoCommerce.XCatalog.Data.Queries
             IAggregationConverter aggregationConverter,
             ISearchPhraseParser phraseParser,
             IProductSortingService productSortingService)
-            : this(searchProvider, mapper, storeCurrencyResolver, storeService, pipeline, aggregationConverter, phraseParser, productSortingService, null)
+            : this(searchProvider, mapper, storeCurrencyResolver, storeService, pipeline, aggregationConverter, phraseParser, productSortingService, null, null)
         {
         }
 
@@ -108,6 +136,8 @@ namespace VirtoCommerce.XCatalog.Data.Queries
             MultilanguagePropertyNames = _propertyService != null
                 ? (await _propertyService.GetAllCatalogPropertiesAsync(store.Catalog)).GetMultilanguagePropertyNames()
                 : [];
+
+            CertainDate = await ResolveCertainDateAsync();
 
             // Sortings are resolved further down (after the filter is parsed into the request builder), so a
             // resolver can read the current category (id / outline) rather than scraping the raw filter string.
@@ -182,7 +212,7 @@ namespace VirtoCommerce.XCatalog.Data.Queries
 
             ApplyOutlineCriteria(criteria, searchRequest);
 
-            var searchResult = await _searchProvider.SearchAsync(KnownDocumentTypes.Product, searchRequest);
+            var searchResult = await SearchProductsAsync(searchRequest);
 
             var resultAggregations = await ConvertAggregations(searchResult, searchRequest, criteria);
 
@@ -206,6 +236,141 @@ namespace VirtoCommerce.XCatalog.Data.Queries
             return result;
         }
 
+        /// <summary>
+        /// The single point through which this handler reaches the search provider, so that both query types
+        /// it serves - <see cref="SearchProductQuery"/> and <see cref="LoadProductsQuery"/>, the latter
+        /// re-entering through the former - go through one overridable call.
+        /// </summary>
+        /// <remarks>
+        /// An override replacing this with a caching implementation takes on four obligations, none of which
+        /// the compiler or a passing test will remind it about:
+        /// <br/><br/>
+        /// <b>Key completeness.</b> The response is a pure function of the two arguments
+        /// <see cref="ISearchProvider.SearchAsync"/> receives, so a key derived from the whole
+        /// <see cref="SearchRequest"/> is complete by construction. Enumerating selected fields instead is
+        /// how a key silently goes under-inclusive - note that entitlement reaches the provider only as
+        /// filters written into <see cref="SearchRequest.Filter"/>, not as anything the builder carries
+        /// alongside. Anything read from ambient state rather than from the request must be in the key too.
+        /// <br/><br/>
+        /// <b>Response isolation.</b> Callers mutate what they receive - the aggregation converter rewrites
+        /// ids on <c>AggregationResponseValue</c> in place, and <c>SetAppliedAggregations</c> writes back to
+        /// the request. A cached entry handed out twice unmodified therefore corrupts the second caller. Copy
+        /// on the way out, on <b>both</b> paths: a store-the-task cache hands the first caller the very
+        /// instance every later caller gets.
+        /// <br/><br/>
+        /// <b>Derived state.</b> The copy must carry whatever a derived response type adds. The default copy
+        /// below cannot do that for a type it does not know, and
+        /// <c>AbstractTypeFactory.TryCreateInstance</c> cannot either - it resolves by the base type's name
+        /// and copies no state. A derived type is the overrider's to preserve.
+        /// <br/><br/>
+        /// <b>Failure semantics.</b> A faulted search must not be retried for the rest of the request; the
+        /// request-scoped cache stores the faulted task and rethrows it, which is the intended behaviour.
+        /// </remarks>
+        protected virtual Task<SearchResponse> SearchProductsAsync(SearchRequest searchRequest)
+        {
+            var cache = _requestScopedCacheAccessor?.Cache;
+
+            // No ambient request scope: nothing to bound the entry to, so the caller gets the provider's own
+            // instance - the behaviour this handler had before the cache existed.
+            if (cache is null)
+            {
+                return _searchProvider.SearchAsync(KnownDocumentTypes.Product, searchRequest);
+            }
+
+            return SearchProductsThroughCacheAsync(cache, searchRequest);
+        }
+
+        private async Task<SearchResponse> SearchProductsThroughCacheAsync(IRequestScopedCache cache, SearchRequest searchRequest)
+        {
+            var response = await cache.GetOrAddAsync(
+                BuildSearchCacheKey(searchRequest),
+                () => _searchProvider.SearchAsync(KnownDocumentTypes.Product, searchRequest));
+
+            // Copy on the miss as well as the hit. The cache stores the TASK the factory returned, so the
+            // caller that populated the entry holds the very instance every later caller will be handed;
+            // cloning only on the hit would leave the first caller aliased to all the others.
+            return CloneSearchResponse(response);
+        }
+
+        /// <summary>
+        /// Key for one provider call. Complete by construction: <see cref="ISearchProvider.SearchAsync"/>
+        /// takes exactly the document type and the request, so hashing the whole request covers every input.
+        /// </summary>
+        /// <remarks>
+        /// The hash is over the request as a graph, not over selected fields - a hand-written projection goes
+        /// silently under-inclusive the day upstream adds a field, and serves the wrong documents. Note that
+        /// <c>ObjectIds</c> order is NOT canonicalised: it drives <c>IdsFilter.Values</c> and <c>Take</c>, so
+        /// two orders are two different calls and hashing verbatim is correct.
+        /// <br/><br/>
+        /// Keyed on <c>GetType()</c> rather than this class, so a subclass that alters the search cannot
+        /// collide with the base handler's entries.
+        /// </remarks>
+        protected virtual string BuildSearchCacheKey(SearchRequest searchRequest)
+        {
+            return CacheKey.With(GetType(), nameof(SearchProductsAsync), KnownDocumentTypes.Product, searchRequest.GetJsonSha256Hex());
+        }
+
+        /// <summary>
+        /// A per-caller copy of a response that may be handed out more than once.
+        /// </summary>
+        /// <remarks>
+        /// Deep only where something downstream writes. <c>AggregationResponse.Id</c> and the ids on its
+        /// <c>Values</c> are both rewritten in place by the aggregation converter's range handling, so
+        /// sharing either would let one caller's conversion rewrite another's data - the values are the
+        /// half that is easy to miss, because copying only the <c>AggregationResponse</c> looks complete.
+        /// <c>Documents</c> and <c>Statistics</c> are shared deliberately: nothing on this path writes to
+        /// them, and documents are the large part of a response.
+        /// <br/><br/>
+        /// Deliberately <c>new SearchResponse()</c> rather than <c>AbstractTypeFactory</c>: that factory
+        /// resolves by the base type's NAME, so it would return the registered override type for a source
+        /// that is a plain base instance, and it copies no state either way. Neither plain construction nor
+        /// the factory can preserve a derived type - hence this is <c>virtual</c>, and preserving derived
+        /// state is stated as the overrider's obligation on <see cref="SearchProductsAsync"/>.
+        /// </remarks>
+        protected virtual SearchResponse CloneSearchResponse(SearchResponse source)
+        {
+            return new SearchResponse
+            {
+                TotalCount = source.TotalCount,
+                Documents = source.Documents,
+                Aggregations = source.Aggregations?.Select(CloneAggregationResponse).ToList(),
+            };
+        }
+
+        /// <summary>
+        /// Copy of one aggregation, deep through its values. <c>Values</c> has no initializer, so null is
+        /// its default and a real response can carry it.
+        /// </summary>
+        protected virtual AggregationResponse CloneAggregationResponse(AggregationResponse source)
+        {
+            return new AggregationResponse
+            {
+                Id = source.Id,
+                Statistics = source.Statistics,
+                Values = source.Values?.Select(x => new AggregationResponseValue { Id = x.Id, Count = x.Count }).ToList(),
+            };
+        }
+
+        // A cache keyed on a request that embeds a clock reading can never hit. AddCertainDateFilter writes
+        // the value as "O" - 100-nanosecond precision - into the filter tree, so two otherwise identical
+        // searches in one request differ on it alone and every lookup misses: no error, no log, just a cache
+        // that never helps. Pinning one instant per request is the precondition for the deduplication below,
+        // not an optimisation on top of it.
+        //
+        // No ambient request scope (a background job, startup) means nothing to bound the value to, so each
+        // send reads its own clock - which is the behaviour that existed before this method.
+        private Task<DateTime> ResolveCertainDateAsync()
+        {
+            var cache = _requestScopedCacheAccessor?.Cache;
+
+            if (cache is null)
+            {
+                return Task.FromResult(DateTime.UtcNow);
+            }
+
+            return cache.GetOrAddAsync(ModuleConstants.CertainDateRequestCacheKey, () => Task.FromResult(DateTime.UtcNow));
+        }
+
         protected virtual IndexSearchRequestBuilder GetIndexedSearchRequestBuilder(SearchProductQuery request, Store store, CoreModule.Core.Currency.Currency currency)
         {
             var builder = new IndexSearchRequestBuilder()
@@ -215,7 +380,7 @@ namespace VirtoCommerce.XCatalog.Data.Queries
                                             .WithCatalog(store.Catalog)
                                             .WithCurrency(currency.Code)
                                             .WithFuzzy(request.Fuzzy, request.FuzzyLevel)
-                                            .AddCertainDateFilter(DateTime.UtcNow)
+                                            .AddCertainDateFilter(CertainDate ?? DateTime.UtcNow)
                                             .WithMultilanguageProperties(MultilanguagePropertyNames)
                                             .WithCultureName(request.CultureName)
                                             .ParseFilters(_phraseParser, request.Filter)

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
@@ -251,7 +251,7 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         /// holder of that entry.
         /// </para>
         /// </remarks>
-        protected virtual Task<SearchResponse> SearchProductsAsync(SearchRequest searchRequest)
+        protected virtual async Task<SearchResponse> SearchProductsAsync(SearchRequest searchRequest)
         {
             var cache = _requestScopedCacheAccessor?.Cache;
 
@@ -259,14 +259,9 @@ namespace VirtoCommerce.XCatalog.Data.Queries
             // instance - the behaviour this handler had before the cache existed.
             if (cache is null)
             {
-                return _searchProvider.SearchAsync(KnownDocumentTypes.Product, searchRequest);
+                return await _searchProvider.SearchAsync(KnownDocumentTypes.Product, searchRequest);
             }
 
-            return SearchProductsCachedAsync(cache, searchRequest);
-        }
-
-        private async Task<SearchResponse> SearchProductsCachedAsync(IRequestScopedCache cache, SearchRequest searchRequest)
-        {
             var response = await cache.GetOrAddAsync(
                 BuildSearchCacheKey(searchRequest),
                 () => _searchProvider.SearchAsync(KnownDocumentTypes.Product, searchRequest));

--- a/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Queries/SearchProductQueryHandler.cs
@@ -21,7 +21,6 @@ using VirtoCommerce.XCatalog.Core;
 using VirtoCommerce.XCatalog.Core.Extensions;
 using VirtoCommerce.XCatalog.Core.Models;
 using VirtoCommerce.XCatalog.Core.Queries;
-using VirtoCommerce.XCatalog.Data.Extensions;
 using VirtoCommerce.XCatalog.Data.Index;
 using Aggregation = VirtoCommerce.CatalogModule.Core.Model.Search.Aggregation;
 using CatalogProductSorting = VirtoCommerce.CatalogModule.Core.Search.Sorting.ProductSorting;
@@ -215,7 +214,7 @@ namespace VirtoCommerce.XCatalog.Data.Queries
             // Mark applied aggregation items
             searchRequest.SetAppliedAggregations(resultAggregations);
 
-            var result = OverridableType<SearchProductResponse>.New();
+            var result = AbstractTypeFactory<SearchProductResponse>.TryCreateInstance();
             result.Query = request;
             result.UserFilters = builder.UserFilters;
             result.GeneratedFilters = builder.GeneratedFilters;
@@ -309,7 +308,7 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         /// </remarks>
         protected virtual SearchResponse CloneSearchResponse(SearchResponse source)
         {
-            var clone = OverridableType<SearchResponse>.New();
+            var clone = AbstractTypeFactory<SearchResponse>.TryCreateInstance();
 
             clone.TotalCount = source.TotalCount;
             clone.Documents = source.Documents;
@@ -324,7 +323,7 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         /// </summary>
         protected virtual AggregationResponse CloneAggregationResponse(AggregationResponse source)
         {
-            var clone = OverridableType<AggregationResponse>.New();
+            var clone = AbstractTypeFactory<AggregationResponse>.TryCreateInstance();
 
             clone.Id = source.Id;
             clone.Statistics = source.Statistics;
@@ -338,7 +337,7 @@ namespace VirtoCommerce.XCatalog.Data.Queries
         /// </summary>
         protected virtual AggregationResponseValue CloneAggregationResponseValue(AggregationResponseValue source)
         {
-            var clone = OverridableType<AggregationResponseValue>.New();
+            var clone = AbstractTypeFactory<AggregationResponseValue>.TryCreateInstance();
 
             clone.Id = source.Id;
             clone.Count = source.Count;

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1016.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1039.0</platformVersion>
+  <platformVersion>3.1053.0-alpha.13351-vcst-5637-json-hash-extensions</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Catalog" version="3.1032.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.1003.0" optional="true" />

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1016.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1053.0-alpha.13351-vcst-5637-json-hash-extensions</platformVersion>
+  <platformVersion>3.1057.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Catalog" version="3.1032.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.1003.0" optional="true" />

--- a/tests/VirtoCommerce.XCatalog.Tests/Queries/SearchProductQueryHandlerDeduplicationTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Queries/SearchProductQueryHandlerDeduplicationTests.cs
@@ -130,7 +130,7 @@ namespace VirtoCommerce.XCatalog.Tests.Queries
                 });
         }
 
-        private IRequestScopedCacheAccessor Accessor(IRequestScopedCache cache)
+        private static IRequestScopedCacheAccessor Accessor(IRequestScopedCache cache)
         {
             var accessorMock = new Mock<IRequestScopedCacheAccessor>();
             accessorMock.Setup(x => x.Cache).Returns(cache);

--- a/tests/VirtoCommerce.XCatalog.Tests/Queries/SearchProductQueryHandlerDeduplicationTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Queries/SearchProductQueryHandlerDeduplicationTests.cs
@@ -21,8 +21,10 @@ using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.StoreModule.Core.Services;
 using VirtoCommerce.Xapi.Core.Pipelines;
 using VirtoCommerce.Xapi.Tests.Helpers;
+using VirtoCommerce.XCatalog.Core;
 using VirtoCommerce.XCatalog.Core.Models;
 using VirtoCommerce.XCatalog.Core.Queries;
+using VirtoCommerce.XCatalog.Data.Index;
 using VirtoCommerce.XCatalog.Data.Queries;
 using Xunit;
 using Aggregation = VirtoCommerce.CatalogModule.Core.Model.Search.Aggregation;
@@ -128,11 +130,16 @@ namespace VirtoCommerce.XCatalog.Tests.Queries
                 });
         }
 
-        private TestableHandler GetHandler(IRequestScopedCache cache = null)
+        private IRequestScopedCacheAccessor Accessor(IRequestScopedCache cache)
         {
             var accessorMock = new Mock<IRequestScopedCacheAccessor>();
             accessorMock.Setup(x => x.Cache).Returns(cache);
 
+            return accessorMock.Object;
+        }
+
+        private TestableHandler GetHandler(IRequestScopedCache cache = null)
+        {
             return new TestableHandler(
                 _searchProviderMock.Object,
                 _mapperMock.Object,
@@ -143,7 +150,7 @@ namespace VirtoCommerce.XCatalog.Tests.Queries
                 _phraseParserMock.Object,
                 _productSortingServiceMock.Object,
                 _propertyServiceMock.Object,
-                accessorMock.Object);
+                Accessor(cache));
         }
 
         private static SearchProductQuery Query(string keyword = null) => new()
@@ -156,24 +163,26 @@ namespace VirtoCommerce.XCatalog.Tests.Queries
         };
 
         [Fact]
-        public async Task Handle_TwoDifferentSearchesInOneScope_ShareOneCertainDate()
+        public async Task Handle_SearchesInOneScope_UseTheInstantPinnedInThatScope()
         {
-            // Two DIFFERENT searches, so both reach the provider and both certain-date filters are observable.
-            // The converse is deliberately not asserted by comparing two DateTime.UtcNow reads for inequality:
-            // they can land in the same tick and such a test would flake. B15 covers the no-scope case
-            // behaviourally instead.
-            var handler = GetHandler(new RequestScopedCache());
+            // Deterministic instead of clock-dependent. Asserting only that two searches agree would rest on
+            // DateTime.UtcNow advancing between two fully-mocked Handle calls, which nothing here forces: on
+            // a host with coarse clock granularity both reads land in one step, the two values match anyway,
+            // and the test would pass with the pinning deleted. Pinning a known instant up front instead
+            // asserts the stronger property — the handler READS the shared value — and fails deterministically
+            // when it stops doing so.
+            var pinned = new DateTime(2020, 5, 17, 4, 32, 11, DateTimeKind.Utc);
+            var cache = new RequestScopedCache();
+            await cache.GetOrAddAsync(ModuleConstants.CertainDateRequestCacheKey, () => Task.FromResult(pinned));
+
+            var handler = GetHandler(cache);
 
             await handler.Handle(Query("first"), CancellationToken.None);
             await handler.Handle(Query("second"), CancellationToken.None);
 
             _capturedSearchRequests.Should().HaveCount(2);
-
-            var first = CertainDateOf(_capturedSearchRequests[0]);
-            var second = CertainDateOf(_capturedSearchRequests[1]);
-
-            first.Should().NotBeNull("the certain-date filter must be present for this test to mean anything");
-            second.Should().Be(first);
+            CertainDateOf(_capturedSearchRequests[0]).Should().Be(pinned.ToString("O"));
+            CertainDateOf(_capturedSearchRequests[1]).Should().Be(pinned.ToString("O"));
         }
 
         [Fact]
@@ -321,8 +330,16 @@ namespace VirtoCommerce.XCatalog.Tests.Queries
         }
 
         [Fact]
-        public void CloneSearchResponse_DerivedSourceWithOverriddenClone_PreservesDerivedState()
+        public async Task SearchProductsAsync_OverriddenClone_IsTheOneTheCachePathUses()
         {
+            // Driven through the cache path rather than by calling the override directly: calling it directly
+            // would exercise only this test's own code and could fail for nothing but the removal of
+            // `virtual`. Going through SearchProductsAsync proves the seam actually routes copies through
+            // the overridable member, which is what the contract promises an overrider.
+            _searchProviderMock
+                .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<SearchRequest>()))
+                .ReturnsAsync(() => new DerivedSearchResponse { TotalCount = 5, Marker = "derived" });
+
             var handler = new DerivedAwareHandler(
                 _searchProviderMock.Object,
                 _mapperMock.Object,
@@ -333,12 +350,16 @@ namespace VirtoCommerce.XCatalog.Tests.Queries
                 _phraseParserMock.Object,
                 _productSortingServiceMock.Object,
                 _propertyServiceMock.Object,
-                Mock.Of<IRequestScopedCacheAccessor>());
+                Accessor(new RequestScopedCache()));
 
-            var clone = handler.CallCloneSearchResponse(new DerivedSearchResponse { TotalCount = 5, Marker = "derived" });
+            var request = new SearchRequest();
+            var onMiss = await handler.CallSearchProductsAsync(request);
+            var onHit = await handler.CallSearchProductsAsync(request);
 
-            clone.Should().BeOfType<DerivedSearchResponse>();
-            ((DerivedSearchResponse)clone).Marker.Should().Be("derived");
+            onMiss.Should().BeOfType<DerivedSearchResponse>();
+            onHit.Should().BeOfType<DerivedSearchResponse>();
+            ((DerivedSearchResponse)onHit).Marker.Should().Be("derived");
+            onHit.Should().NotBeSameAs(onMiss);
         }
 
         [Fact]
@@ -370,10 +391,12 @@ namespace VirtoCommerce.XCatalog.Tests.Queries
         public void BuildSearchCacheKey_DifferingObjectIdsOrder_AreDistinct()
         {
             // ObjectIds order is meaningful - it drives IdsFilter.Values and Take - so it is deliberately NOT
-            // canonicalised, and two orders must key differently.
+            // canonicalised. Built through the real AddObjectIds rather than by hand-rolling an IdsFilter:
+            // hand-rolling would only prove the hash is list-order-sensitive, and would keep passing if
+            // AddObjectIds ever started sorting, which is exactly the property under test.
             var handler = GetHandler();
-            var first = new SearchRequest { Filter = new IdsFilter { Values = ["a", "b"] } };
-            var second = new SearchRequest { Filter = new IdsFilter { Values = ["b", "a"] } };
+            var first = new IndexSearchRequestBuilder().AddObjectIds(["a", "b"]).Build();
+            var second = new IndexSearchRequestBuilder().AddObjectIds(["b", "a"]).Build();
 
             handler.CallBuildSearchCacheKey(first).Should().NotBe(handler.CallBuildSearchCacheKey(second));
         }

--- a/tests/VirtoCommerce.XCatalog.Tests/Queries/SearchProductQueryHandlerDeduplicationTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Queries/SearchProductQueryHandlerDeduplicationTests.cs
@@ -1,0 +1,537 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using FluentAssertions;
+using Moq;
+using Newtonsoft.Json;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Model.Search;
+using VirtoCommerce.CatalogModule.Core.Search;
+using VirtoCommerce.CatalogModule.Core.Search.Sorting;
+using VirtoCommerce.CatalogModule.Core.Services;
+using VirtoCommerce.CoreModule.Core.Currency;
+using VirtoCommerce.Platform.Caching;
+using VirtoCommerce.Platform.Core.Caching;
+using VirtoCommerce.SearchModule.Core.Model;
+using VirtoCommerce.SearchModule.Core.Services;
+using VirtoCommerce.StoreModule.Core.Model;
+using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.Xapi.Core.Pipelines;
+using VirtoCommerce.Xapi.Tests.Helpers;
+using VirtoCommerce.XCatalog.Core.Models;
+using VirtoCommerce.XCatalog.Core.Queries;
+using VirtoCommerce.XCatalog.Data.Queries;
+using Xunit;
+using Aggregation = VirtoCommerce.CatalogModule.Core.Model.Search.Aggregation;
+using CatalogProductSorting = VirtoCommerce.CatalogModule.Core.Search.Sorting.ProductSorting;
+
+namespace VirtoCommerce.XCatalog.Tests.Queries
+{
+    /// <summary>
+    /// End-to-end tests for the request-scoped search deduplication. These drive <c>Handle</c> rather than a
+    /// projection helper, which is why they need the fixture below - the pre-existing product-handler tests
+    /// only exercise <c>BuildSortings</c> and never reach the search provider.
+    /// </summary>
+    public class SearchProductQueryHandlerDeduplicationTests : BaseMoqHelper
+    {
+        private const string CATALOG_ID = "catalog-1";
+        private const string START_DATE_FIELD = "startdate";
+
+        private readonly Mock<ISearchProvider> _searchProviderMock = new();
+        private readonly Mock<IMapper> _mapperMock = new();
+        private readonly Mock<IStoreCurrencyResolver> _storeCurrencyResolverMock = new();
+        private readonly Mock<IStoreService> _storeServiceMock = new();
+        private readonly Mock<IGenericPipelineLauncher> _pipelineMock = new();
+        private readonly Mock<IAggregationConverter> _aggregationConverterMock = new();
+        private readonly Mock<ISearchPhraseParser> _phraseParserMock = new();
+        private readonly Mock<IProductSortingService> _productSortingServiceMock = new();
+        private readonly Mock<IPropertyService> _propertyServiceMock = new();
+
+        // Provider calls, NOT Handle entries: Handle(LoadProductsQuery) re-enters Handle(SearchProductQuery),
+        // so counting handler entries double-counts a single logical search.
+        private readonly List<SearchRequest> _capturedSearchRequests = [];
+
+        public SearchProductQueryHandlerDeduplicationTests()
+        {
+            var currency = GetCurrency();
+
+            _storeCurrencyResolverMock
+                .Setup(x => x.GetAllStoreCurrenciesAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync([currency]);
+
+            _storeCurrencyResolverMock
+                .Setup(x => x.GetStoreCurrencyAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(currency);
+
+            // GetByIdAsync is an extension over ICrudService.GetAsync, so the mock has to target GetAsync.
+            // Languages must be non-null: Handle reads store.Languages.Contains(...) before anything else.
+            _storeServiceMock
+                .Setup(x => x.GetAsync(It.IsAny<IList<string>>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync([new Store
+                {
+                    Id = DEFAULT_STORE_ID,
+                    Catalog = CATALOG_ID,
+                    Languages = [CULTURE_NAME],
+                    DefaultLanguage = CULTURE_NAME,
+                    DefaultCurrency = CURRENCY_CODE,
+                }]);
+
+            _propertyServiceMock
+                .Setup(x => x.GetAllCatalogPropertiesAsync(It.IsAny<string>()))
+                .ReturnsAsync([]);
+
+            _productSortingServiceMock
+                .Setup(x => x.GetSortingsAsync(It.IsAny<ProductSortingContext>()))
+                .ReturnsAsync(new List<CatalogProductSorting>());
+
+            // Non-null aggregations: ConvertAggregations feeds ApplyFacetLocalization and SetAppliedAggregations.
+            _aggregationConverterMock
+                .Setup(x => x.ConvertAggregationsAsync(It.IsAny<IList<AggregationResponse>>(), It.IsAny<ProductIndexedSearchCriteria>()))
+                .ReturnsAsync([]);
+
+            _mapperMock
+                .Setup(x => x.Map<ExpProduct>(It.IsAny<object>()))
+                .Returns(() => new ExpProduct());
+
+            SetupProviderResponse();
+        }
+
+        // Every instance the provider hands out is recorded, so a test can assert that NO caller ever holds
+        // it. Comparing the two callers against each other is not enough: cloning only on the hit would
+        // still make them differ, while leaving the first caller aliased to the cached instance.
+        private readonly List<SearchResponse> _providerResponses = [];
+
+        private void SetupProviderResponse()
+        {
+            _searchProviderMock
+                .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<SearchRequest>()))
+                .Callback<string, SearchRequest>((_, request) => _capturedSearchRequests.Add(request))
+                .ReturnsAsync(() =>
+                {
+                    var response = new SearchResponse
+                    {
+                        TotalCount = 1,
+                        Documents = [new SearchDocument { Id = "doc-1" }],
+                        Aggregations = [new AggregationResponse
+                        {
+                            Id = "brand",
+                            Values = [new AggregationResponseValue { Id = "acme", Count = 3 }],
+                        }],
+                    };
+
+                    _providerResponses.Add(response);
+
+                    return response;
+                });
+        }
+
+        private TestableHandler GetHandler(IRequestScopedCache cache = null)
+        {
+            var accessorMock = new Mock<IRequestScopedCacheAccessor>();
+            accessorMock.Setup(x => x.Cache).Returns(cache);
+
+            return new TestableHandler(
+                _searchProviderMock.Object,
+                _mapperMock.Object,
+                _storeCurrencyResolverMock.Object,
+                _storeServiceMock.Object,
+                _pipelineMock.Object,
+                _aggregationConverterMock.Object,
+                _phraseParserMock.Object,
+                _productSortingServiceMock.Object,
+                _propertyServiceMock.Object,
+                accessorMock.Object);
+        }
+
+        private static SearchProductQuery Query(string keyword = null) => new()
+        {
+            StoreId = DEFAULT_STORE_ID,
+            CultureName = CULTURE_NAME,
+            CurrencyCode = CURRENCY_CODE,
+            Query = keyword,
+            IncludeFields = ["id"],
+        };
+
+        [Fact]
+        public async Task Handle_TwoDifferentSearchesInOneScope_ShareOneCertainDate()
+        {
+            // Two DIFFERENT searches, so both reach the provider and both certain-date filters are observable.
+            // The converse is deliberately not asserted by comparing two DateTime.UtcNow reads for inequality:
+            // they can land in the same tick and such a test would flake. B15 covers the no-scope case
+            // behaviourally instead.
+            var handler = GetHandler(new RequestScopedCache());
+
+            await handler.Handle(Query("first"), CancellationToken.None);
+            await handler.Handle(Query("second"), CancellationToken.None);
+
+            _capturedSearchRequests.Should().HaveCount(2);
+
+            var first = CertainDateOf(_capturedSearchRequests[0]);
+            var second = CertainDateOf(_capturedSearchRequests[1]);
+
+            first.Should().NotBeNull("the certain-date filter must be present for this test to mean anything");
+            second.Should().Be(first);
+        }
+
+        [Fact]
+        public async Task Handle_TwoIdenticalSearchesInOneScope_CallTheProviderOnce()
+        {
+            var handler = GetHandler(new RequestScopedCache());
+
+            await handler.Handle(Query("shoes"), CancellationToken.None);
+            await handler.Handle(Query("shoes"), CancellationToken.None);
+
+            _capturedSearchRequests.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task Handle_TwoDifferentSearchesInOneScope_CallTheProviderTwice()
+        {
+            var handler = GetHandler(new RequestScopedCache());
+
+            await handler.Handle(Query("shoes"), CancellationToken.None);
+            await handler.Handle(Query("boots"), CancellationToken.None);
+
+            _capturedSearchRequests.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public async Task Handle_WithoutAmbientScope_CallsTheProviderPerSendAndReturnsItsOwnInstance()
+        {
+            // The pre-cache behaviour, which the null-accessor path must preserve exactly.
+            var handler = GetHandler(cache: null);
+
+            await handler.Handle(Query("shoes"), CancellationToken.None);
+            await handler.Handle(Query("shoes"), CancellationToken.None);
+
+            _capturedSearchRequests.Should().HaveCount(2);
+
+            var response = new SearchResponse();
+            _searchProviderMock
+                .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<SearchRequest>()))
+                .ReturnsAsync(response);
+
+            var returned = await handler.CallSearchProductsAsync(new SearchRequest());
+
+            returned.Should().BeSameAs(response, "with no cache there is nothing to isolate callers from");
+        }
+
+        [Fact]
+        public async Task SearchProductsAsync_CachedHitAndMiss_BothReturnACopy()
+        {
+            // The miss matters as much as the hit: the cache stores the task the factory returned, so the
+            // caller that populated the entry holds the instance every later caller is handed.
+            var handler = GetHandler(new RequestScopedCache());
+            var request = new SearchRequest();
+
+            var onMiss = await handler.CallSearchProductsAsync(request);
+            var onHit = await handler.CallSearchProductsAsync(request);
+
+            _capturedSearchRequests.Should().HaveCount(1);
+
+            // The load-bearing assertion: the caller that POPULATED the entry must not hold the cached
+            // instance either. Cloning only on the hit passes an onHit-vs-onMiss comparison while leaving
+            // this one aliased.
+            onMiss.Should().NotBeSameAs(_providerResponses[0]);
+            onHit.Should().NotBeSameAs(_providerResponses[0]);
+
+            onHit.Should().NotBeSameAs(onMiss);
+            onHit.Aggregations[0].Should().NotBeSameAs(onMiss.Aggregations[0]);
+            onHit.Aggregations[0].Values[0].Should().NotBeSameAs(onMiss.Aggregations[0].Values[0]);
+        }
+
+        [Fact]
+        public async Task SearchProductsAsync_FaultedSearch_PropagatesAndIsNotRetried()
+        {
+            _searchProviderMock
+                .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<SearchRequest>()))
+                .Callback<string, SearchRequest>((_, request) => _capturedSearchRequests.Add(request))
+                .ThrowsAsync(new InvalidOperationException("index unavailable"));
+
+            var handler = GetHandler(new RequestScopedCache());
+            var request = new SearchRequest();
+
+            await FluentActions.Awaiting(() => handler.CallSearchProductsAsync(request)).Should().ThrowAsync<InvalidOperationException>();
+            await FluentActions.Awaiting(() => handler.CallSearchProductsAsync(request)).Should().ThrowAsync<InvalidOperationException>();
+
+            _capturedSearchRequests.Should().HaveCount(1, "a faulted load stays cached for the rest of the request");
+        }
+
+        [Fact]
+        public void CloneSearchResponse_TwoClones_ShareNoMutableNode()
+        {
+            var handler = GetHandler();
+            var source = new SearchResponse
+            {
+                TotalCount = 7,
+                Documents = [new SearchDocument { Id = "doc-1" }],
+                Aggregations = [new AggregationResponse
+                {
+                    Id = "brand",
+                    Values = [new AggregationResponseValue { Id = "acme", Count = 3 }],
+                }],
+            };
+
+            var first = handler.CallCloneSearchResponse(source);
+            var second = handler.CallCloneSearchResponse(source);
+
+            first.Should().NotBeSameAs(second);
+            first.Aggregations[0].Should().NotBeSameAs(second.Aggregations[0]);
+            first.Aggregations[0].Values[0].Should().NotBeSameAs(second.Aggregations[0].Values[0]);
+
+            // The aggregation converter rewrites these ids in place; one caller's rewrite must not be visible
+            // to another. This is the assertion a shallow copy of the value list fails.
+            first.Aggregations[0].Id = "rewritten";
+            first.Aggregations[0].Values[0].Id = "rewritten-value";
+
+            second.Aggregations[0].Id.Should().Be("brand");
+            second.Aggregations[0].Values[0].Id.Should().Be("acme");
+            source.Aggregations[0].Values[0].Id.Should().Be("acme");
+        }
+
+        [Fact]
+        public void CloneSearchResponse_NullAggregationsAndValues_AreCarriedThrough()
+        {
+            // Values has no initializer, so null is its default and a real response can carry it.
+            var handler = GetHandler();
+
+            handler.CallCloneSearchResponse(new SearchResponse { Aggregations = null }).Aggregations.Should().BeNull();
+
+            var withNullValues = new SearchResponse { Aggregations = [new AggregationResponse { Id = "brand", Values = null }] };
+
+            handler.CallCloneSearchResponse(withNullValues).Aggregations[0].Values.Should().BeNull();
+        }
+
+        [Fact]
+        public void CloneSearchResponse_DerivedSourceWithDefaultImplementation_DoesNotPreserveDerivedState()
+        {
+            // Stated as the documented contract, not as a guarantee the mechanism can give: neither plain
+            // construction nor AbstractTypeFactory can carry a derived type's own fields. DerivedSearchResponse
+            // is deliberately unknown to the factory, so this cannot pass by coincidence.
+            var handler = GetHandler();
+            var source = new DerivedSearchResponse { TotalCount = 5, Marker = "derived" };
+
+            var clone = handler.CallCloneSearchResponse(source);
+
+            clone.Should().NotBeOfType<DerivedSearchResponse>();
+            clone.TotalCount.Should().Be(5, "base state is still copied");
+        }
+
+        [Fact]
+        public void CloneSearchResponse_DerivedSourceWithOverriddenClone_PreservesDerivedState()
+        {
+            var handler = new DerivedAwareHandler(
+                _searchProviderMock.Object,
+                _mapperMock.Object,
+                _storeCurrencyResolverMock.Object,
+                _storeServiceMock.Object,
+                _pipelineMock.Object,
+                _aggregationConverterMock.Object,
+                _phraseParserMock.Object,
+                _productSortingServiceMock.Object,
+                _propertyServiceMock.Object,
+                Mock.Of<IRequestScopedCacheAccessor>());
+
+            var clone = handler.CallCloneSearchResponse(new DerivedSearchResponse { TotalCount = 5, Marker = "derived" });
+
+            clone.Should().BeOfType<DerivedSearchResponse>();
+            ((DerivedSearchResponse)clone).Marker.Should().Be("derived");
+        }
+
+        [Fact]
+        public void BuildSearchCacheKey_AndFilterVersusOrFilterOverIdenticalChildren_AreDistinct()
+        {
+            var handler = GetHandler();
+            var and = new SearchRequest { Filter = new AndFilter { ChildFilters = Children() } };
+            var or = new SearchRequest { Filter = new OrFilter { ChildFilters = Children() } };
+
+            handler.CallBuildSearchCacheKey(and).Should().NotBe(handler.CallBuildSearchCacheKey(or));
+        }
+
+        [Fact]
+        public void BuildSearchCacheKey_WithoutTypeDiscriminator_AndFilterAndOrFilterCollide()
+        {
+            // Fixture check for the test above: AndFilter and OrFilter each declare only ChildFilters, so
+            // without $type they really are indistinguishable. That makes the pass above evidence about the
+            // discriminator rather than about some incidental difference between the two filter types.
+            var withoutDiscriminator = JsonHashExtensions.CreateCacheKeySettings();
+            withoutDiscriminator.TypeNameHandling = TypeNameHandling.None;
+
+            var and = new SearchRequest { Filter = new AndFilter { ChildFilters = Children() } };
+            var or = new SearchRequest { Filter = new OrFilter { ChildFilters = Children() } };
+
+            and.GetJsonSha256Hex(withoutDiscriminator).Should().Be(or.GetJsonSha256Hex(withoutDiscriminator));
+        }
+
+        [Fact]
+        public void BuildSearchCacheKey_DifferingObjectIdsOrder_AreDistinct()
+        {
+            // ObjectIds order is meaningful - it drives IdsFilter.Values and Take - so it is deliberately NOT
+            // canonicalised, and two orders must key differently.
+            var handler = GetHandler();
+            var first = new SearchRequest { Filter = new IdsFilter { Values = ["a", "b"] } };
+            var second = new SearchRequest { Filter = new IdsFilter { Values = ["b", "a"] } };
+
+            handler.CallBuildSearchCacheKey(first).Should().NotBe(handler.CallBuildSearchCacheKey(second));
+        }
+
+        [Fact]
+        public async Task Handle_SeamOverridden_ServesBothQueryTypesWithoutTouchingTheProvider()
+        {
+            // The "one call site" claim, checked behaviourally. A unit test cannot prove a class contains
+            // exactly one call site; it can prove nothing bypasses the seam at runtime.
+            var handler = new SeamOverridingHandler(
+                _searchProviderMock.Object,
+                _mapperMock.Object,
+                _storeCurrencyResolverMock.Object,
+                _storeServiceMock.Object,
+                _pipelineMock.Object,
+                _aggregationConverterMock.Object,
+                _phraseParserMock.Object,
+                _productSortingServiceMock.Object,
+                _propertyServiceMock.Object,
+                Mock.Of<IRequestScopedCacheAccessor>());
+
+            _mapperMock
+                .Setup(x => x.Map<SearchProductQuery>(It.IsAny<LoadProductsQuery>()))
+                .Returns(() => Query("mapped"));
+
+            await handler.Handle(Query("direct"), CancellationToken.None);
+            await handler.Handle(new LoadProductsQuery { StoreId = DEFAULT_STORE_ID, ObjectIds = ["p-1"] }, CancellationToken.None);
+
+            handler.SeamCalls.Should().Be(2);
+            _capturedSearchRequests.Should().BeEmpty("every provider access goes through the seam");
+        }
+
+        private static IList<IFilter> Children() =>
+        [
+            new TermFilter { FieldName = "color", Values = ["red"] },
+            new TermFilter { FieldName = "size", Values = ["m"] },
+        ];
+
+        // The certain date lands as the upper bound of the "startdate" range filter, written with "O".
+        private static string CertainDateOf(SearchRequest request) =>
+            FindRangeFilters(request.Filter)
+                .FirstOrDefault(x => x.FieldName == START_DATE_FIELD)?
+                .Values?.FirstOrDefault()?.Upper;
+
+        private static IEnumerable<RangeFilter> FindRangeFilters(IFilter filter)
+        {
+            switch (filter)
+            {
+                case RangeFilter range:
+                    yield return range;
+                    break;
+
+                case AndFilter and:
+                    foreach (var found in and.ChildFilters.SelectMany(FindRangeFilters))
+                    {
+                        yield return found;
+                    }
+
+                    break;
+
+                case OrFilter or:
+                    foreach (var found in or.ChildFilters.SelectMany(FindRangeFilters))
+                    {
+                        yield return found;
+                    }
+
+                    break;
+            }
+        }
+
+        private sealed class DerivedSearchResponse : SearchResponse
+        {
+            public string Marker { get; set; }
+        }
+
+        private class TestableHandler : SearchProductQueryHandler
+        {
+            public TestableHandler(
+                ISearchProvider searchProvider,
+                IMapper mapper,
+                IStoreCurrencyResolver storeCurrencyResolver,
+                IStoreService storeService,
+                IGenericPipelineLauncher pipeline,
+                IAggregationConverter aggregationConverter,
+                ISearchPhraseParser phraseParser,
+                IProductSortingService productSortingService,
+                IPropertyService propertyService,
+                IRequestScopedCacheAccessor requestScopedCacheAccessor)
+                : base(searchProvider, mapper, storeCurrencyResolver, storeService, pipeline, aggregationConverter, phraseParser, productSortingService, propertyService, requestScopedCacheAccessor)
+            {
+            }
+
+            public Task<SearchResponse> CallSearchProductsAsync(SearchRequest searchRequest) => SearchProductsAsync(searchRequest);
+
+            public SearchResponse CallCloneSearchResponse(SearchResponse source) => CloneSearchResponse(source);
+
+            public string CallBuildSearchCacheKey(SearchRequest searchRequest) => BuildSearchCacheKey(searchRequest);
+        }
+
+        private sealed class DerivedAwareHandler : TestableHandler
+        {
+            public DerivedAwareHandler(
+                ISearchProvider searchProvider,
+                IMapper mapper,
+                IStoreCurrencyResolver storeCurrencyResolver,
+                IStoreService storeService,
+                IGenericPipelineLauncher pipeline,
+                IAggregationConverter aggregationConverter,
+                ISearchPhraseParser phraseParser,
+                IProductSortingService productSortingService,
+                IPropertyService propertyService,
+                IRequestScopedCacheAccessor requestScopedCacheAccessor)
+                : base(searchProvider, mapper, storeCurrencyResolver, storeService, pipeline, aggregationConverter, phraseParser, productSortingService, propertyService, requestScopedCacheAccessor)
+            {
+            }
+
+            protected override SearchResponse CloneSearchResponse(SearchResponse source)
+            {
+                if (source is not DerivedSearchResponse derived)
+                {
+                    return base.CloneSearchResponse(source);
+                }
+
+                return new DerivedSearchResponse
+                {
+                    TotalCount = derived.TotalCount,
+                    Documents = derived.Documents,
+                    Aggregations = derived.Aggregations,
+                    Marker = derived.Marker,
+                };
+            }
+        }
+
+        private sealed class SeamOverridingHandler : TestableHandler
+        {
+            public SeamOverridingHandler(
+                ISearchProvider searchProvider,
+                IMapper mapper,
+                IStoreCurrencyResolver storeCurrencyResolver,
+                IStoreService storeService,
+                IGenericPipelineLauncher pipeline,
+                IAggregationConverter aggregationConverter,
+                ISearchPhraseParser phraseParser,
+                IProductSortingService productSortingService,
+                IPropertyService propertyService,
+                IRequestScopedCacheAccessor requestScopedCacheAccessor)
+                : base(searchProvider, mapper, storeCurrencyResolver, storeService, pipeline, aggregationConverter, phraseParser, productSortingService, propertyService, requestScopedCacheAccessor)
+            {
+            }
+
+            public int SeamCalls { get; private set; }
+
+            protected override Task<SearchResponse> SearchProductsAsync(SearchRequest searchRequest)
+            {
+                SeamCalls++;
+
+                return Task.FromResult(new SearchResponse());
+            }
+        }
+    }
+}

--- a/tests/VirtoCommerce.XCatalog.Tests/Queries/SearchProductQueryHandlerTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Queries/SearchProductQueryHandlerTests.cs
@@ -64,13 +64,26 @@ namespace VirtoCommerce.XCatalog.Tests.Queries
             act.Should().NotThrow();
         }
 
+        [Fact]
+        public void Constructor_ObsoleteOverloadWithoutRequestScopedCacheAccessor_DoesNotThrow()
+        {
+            // Back-compat: callers built against the constructor without IRequestScopedCacheAccessor must
+            // still compile and construct. They get no deduplication — a null accessor is the same
+            // "no ambient request scope" case the handler already has to handle.
+#pragma warning disable VC0015 // Type or member is obsolete
+            var act = () => new SearchProductQueryHandler(null, null, null, null, null, null, null, null, null);
+#pragma warning restore VC0015
+
+            act.Should().NotThrow();
+        }
+
         private static CatalogProductSorting Ordering(string code, string name, bool isVisible, bool isDefault = false) =>
             new() { Code = code, Name = name, IsVisible = isVisible, IsDefault = isDefault };
 
         // BuildSortings does not use any injected dependency, so the base ctor is satisfied with nulls.
         private sealed class TestHandler : SearchProductQueryHandler
         {
-            public TestHandler() : base(null, null, null, null, null, null, null, null, null) { }
+            public TestHandler() : base(null, null, null, null, null, null, null, null, null, null) { }
 
             public IList<XapiProductSorting> Build(IList<CatalogProductSorting> sortings, CatalogProductSorting selected, string languageCode) =>
                 BuildSortings(sortings, selected, languageCode);

--- a/tests/VirtoCommerce.XCatalog.Tests/VirtoCommerce.XCatalog.Tests.csproj
+++ b/tests/VirtoCommerce.XCatalog.Tests/VirtoCommerce.XCatalog.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="VirtoCommerce.Platform.Caching" Version="3.1053.0-alpha.13351-vcst-5637-json-hash-extensions" />
+    <PackageReference Include="VirtoCommerce.Platform.Caching" Version="3.1057.0" />
     <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.1039.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/VirtoCommerce.XCatalog.Tests/VirtoCommerce.XCatalog.Tests.csproj
+++ b/tests/VirtoCommerce.XCatalog.Tests/VirtoCommerce.XCatalog.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="VirtoCommerce.Platform.Caching" Version="3.1053.0-alpha.13351-vcst-5637-json-hash-extensions" />
     <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.1039.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
> **Requires platform `3.1057.0`** — up from `3.1039.0` on `dev`. A deployment running anything between those two stops loading this module rather than failing loudly, so the bump belongs in the release notes. `GetJsonSha256Hex` exists in no earlier release ([vc-platform#3095](https://github.com/VirtoCommerce/vc-platform/pull/3095), merged and cut as `3.1057.0` — the tag is identical to that merge commit), while `IRequestScopedCacheAccessor` has been available since `3.1052.0`; the higher of the two decides the minimum. Three sites name it: `XCatalog.Core.csproj` (`Platform.Core`), `XCatalog.Tests.csproj` (`Platform.Caching`), and `module.manifest`'s `platformVersion`. Understating `platformVersion` is the dangerous direction — it passes the load-time check and then throws `MissingMethodException` on the first product search, i.e. on every request rather than at startup.

## Summary

One GraphQL request issues the same Elasticsearch product search several times — `Handle(LoadProductsQuery)` re-enters `Handle(SearchProductQuery)`, and several fields of one response resolve off the same criteria. Each of those was a separate round-trip. They are now deduplicated for the life of the request through the platform's `IRequestScopedCache`.

## Two things had to exist before a cache could help at all

**A cached call whose argument embeds a clock reading can never hit.** `AddCertainDateFilter` wrote `DateTime.UtcNow` into the filter tree as `"O"` — 100-nanosecond precision — so any key derived from the request differed on every call. The cache would have missed 100% of the time with no error, no log and no wrong answer: just a cache that never helps. One instant is now pinned per request.

It is shared rather than taken per handler, and that is a correctness property, not an optimisation: the date bounds validity windows, so two searches in one response evaluated against different instants can only produce an inconsistent view. Product search is the only consumer today; the key is named for the purpose so a second one can join it.

**A single call site.** Every provider access now goes through one `protected virtual SearchProductsAsync`. Three of the obligations an override takes on — key completeness, response isolation, derived state — are written into its doc-comment, plus the one the shared `Documents` creates. The fourth, that a faulted search is not retried for the rest of the request, is `IRequestScopedCache`'s own documented contract rather than this handler's, and is pinned here by a provider-call-count test. They are not discoverable from the signature, and an override that misses one leaks data rather than failing.

## The key

`CacheKey.With(GetType(), nameof(SearchProductsAsync), KnownDocumentTypes.Product, searchRequest.GetJsonSha256Hex())`.

Hashing the whole request is complete **by construction**: `ISearchProvider.SearchAsync` takes exactly the document type and the request, so the response is a pure function of the two. Enumerating selected fields instead is how a key silently goes under-inclusive the day upstream adds a field — and an under-inclusive key serves the wrong documents rather than costing a miss. Entitlement is safe on the same argument: it reaches the provider only as filters already written into `SearchRequest.Filter`, never as builder state.

`ObjectIds` order is deliberately **not** canonicalised — it drives `IdsFilter.Values` and `Take`, so two orders are two different calls.

One property of the shared helper is worth stating rather than working around: `CacheKey.With(Type, …)` renders the type through `PrettyPrint`, which yields the **short** name, so a subclass keeping the name `SearchProductQueryHandler` in another namespace would key identically to this one. An earlier revision carried a local `GetType().FullName` segment to sidestep that; it is gone. The property belongs to the helper — 79 of its 86 call sites pass a type — and it is unreachable here anyway, because an entry lives for exactly one request, so colliding would take two same-named handler types serving the same request. Fixing the helper is a separate decision about re-keying every cache in the stack.

## Response isolation

Callers mutate what they receive: the aggregation converter rewrites `AggregationResponse.Id` **and** the ids on its `Values` in place. Each caller therefore gets a copy, deep exactly where something writes, sharing `Documents` and `Statistics` (only ever read on this path, and documents are the large part of a response).

The copy runs on the **miss as well as the hit**. The cache stores the task the factory returned, so the caller that populated the entry holds the very instance every later caller is handed; cloning only on the hit would leave the first caller aliased to all the others.

Without an ambient request scope — a background job, startup — the handler behaves exactly as before: its own provider call, its own response instance, no deduplication.

## What this costs where it cannot help

A listing search is issued once per request by construction, so on the browse path the key is built and never reused. Measured on a local stand (1 vCPU, 1500 MiB GC heap cap, 6.1M-product catalog, 14 facets on the page): a browse request allocates **13.2 MB**, of which the key is **154 KB — 1.2%**, or about **1.6%** counting the aggregation clone and the by-ids keys the `variations` resolver issues per master product.

An allocation trace agrees independently: `JsonSerializerInternalWriter.WriteTypeProperty` — which runs only under the cache-key serializer settings, since nothing else here enables `TypeNameHandling` — is 0.5% of sampled allocations, and `SerializeList` another 0.5%. No `IncrementalHash` or `SHA256` frame reaches the top 40, so the hashing is not the cost; the serialization feeding it is.

A shape gate — skip the cache when the request carries aggregations — would remove that, and is deliberately **not** here. It would cost the demonstration arm that shows the dedup collapsing identical `products()` aliases, and the same path is about to be rewritten by the `variations` N+1 follow-up, which removes about a quarter of the figure on its own. Documented rather than shipped silently.

## Behaviour change worth knowing

Reading `IRequestScopedCacheAccessor.Cache` now happens on every product search. Per the accessor's documented contract, a continuation started inside a request but **not awaited by it** carries an ambient context whose request scope has since been disposed, and the read throws `ObjectDisposedException` rather than returning null. That is the platform's intended signal about the caller's lifetime. No such caller exists in this repo — every send is awaited — but a downstream fire-and-forget send would now surface.

## Constructors

The new primary takes `IRequestScopedCacheAccessor`. Both older overloads are `[Obsolete]` and target the primary directly rather than chaining through each other. The new deprecation carries `VC0015`, the current release wave — reusing `VC0016` would have been hidden by the `#pragma warning disable VC0016` already in the test file, at exactly the one call site that had to be retargeted.

## Test plan

The product handler had no end-to-end fixture — its tests reached only `BuildSortings` — so `Handle` is exercised here for the first time. Provider calls are counted, never `Handle` entries: `Handle(LoadProductsQuery)` re-enters `Handle(SearchProductQuery)` and would double-count one logical search.

- [x] `VirtoCommerce.XCatalog.Tests` 142/142; solution builds with 0 warnings.
- [x] The overhead a single-search request pays is measured, not argued. `benchmarks/VirtoCommerce.XCatalog.Benchmark` runs `BuildSearchCacheKey` against fixtures that mirror the call chain of `GetIndexedSearchRequestBuilder` — the platform's `JsonHashBenchmarks` can only hash a synthetic tree, since `Platform.Core` cannot reference a search module. Default job, .NET 10.0.10: a by-ids load costs **5.3 µs / 9.4 KB** at one id and **8.2 µs / 9.4 KB** at a hundred; a catalog-root browse costs **23.6 µs / 46.8 KB** at four facets and **73.1 µs / 154.0 KB** at sixteen.

  Against an Elasticsearch round-trip the added latency is not the interesting number. The allocation on the facet-bearing browse path is: it scales with facet count because `ApplyMultiSelectFacetSearch` clones the filter tree onto every aggregation, and that is the storefront's dominant shape. Allocation on the by-ids path — the one that actually deduplicates — is constant in the id count, which is the streaming writer working as designed.

  These are a **floor**: `ParseFilters` / `ParseFacets` need an `ISearchPhraseParser` and add user filters on top, the module pipeline can extend the request before it is built, and a category browse carries a longer outline that gets cloned into every aggregation. The first version of the fixtures omitted `AddCertainDateFilter` and `ApplyMultiSelectFacetSearch` and so understated by 1.6× and 3–4.5×; a thin fixture does not fail, it quietly reports a smaller number.
- [x] Two identical searches in one scope call the provider once; two differing ones call it twice.
- [x] Searches in one scope use the instant pinned in that scope — **verified discriminating**: deleting the pinning fails this test *and* the dedup test, because unpinned requests differ at 100ns and the cache goes inert. The test pins a known instant rather than comparing two clock reads, which would pass on a host with coarse clock granularity.
- [x] Hit and miss both return a copy, and neither caller holds the instance the provider returned — **verified discriminating**: cloning only on the hit fails it. An earlier version compared the two callers only against each other and passed against that bug.
- [x] Deep-copy isolation through `AggregationResponse` and its `Values` — **verified discriminating**: shallow-copying the value list fails it.
- [x] `AndFilter` vs `OrFilter` over identical children key differently, paired with a fixture check that the two collide once the type discriminator is off — so the pass is evidence about `$type`, not about some incidental difference between the filter types.
- [x] `ObjectIds` order keys differently, built through the real `AddObjectIds` so the test would catch that method starting to sort.
- [x] A faulted search propagates and is not retried for the rest of the request.
- [x] An overridden clone is the one the cache path uses; the default does not preserve a derived type and the test states that as the documented contract rather than asserting a guarantee the mechanism cannot give.
- [x] An override of the seam serves both query types without the provider being touched.
- [x] No ambient scope: provider called once per send, its own instance returned; the obsolete constructors still compile, run, and deduplicate nothing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot product-search path and caching semantics (wrong keys could serve incorrect results); mitigated by full-request hashing, clone-on-every-return, and broad tests, but depends on a prerelease platform package until merge.
> 
> **Overview**
> **Deduplicates repeated product Elasticsearch calls** in a single GraphQL/request scope via `IRequestScopedCache`, routing all provider access through `SearchProductsAsync` with keys built from the full `SearchRequest` JSON hash (`GetJsonSha256Hex`).
> 
> **Pins one “certain date” per request** (`ModuleConstants.CertainDateRequestCacheKey`) so validity-window filters no longer embed a fresh `UtcNow` on every search—which would make cache keys unique and dedup useless. Without an ambient request cache, behavior stays as before (no dedup, per-call clock).
> 
> **Isolates callers** by cloning `SearchResponse` (aggregations deep-copied where downstream mutates) on both cache hit and miss so shared cached tasks do not alias mutable aggregation state.
> 
> Adds **`IRequestScopedCacheAccessor`** to `SearchProductQueryHandler` (obsolete prior ctor with `VC0015`), pins **platform alpha** for JSON hash helpers in Core/manifest, replaces local **`OverridableType`** with **`AbstractTypeFactory.TryCreateInstance`**, and adds a **BenchmarkDotNet** project plus **`SearchProductQueryHandlerDeduplicationTests`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35595b1503e35a7cfe8476ff663536797acf3b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5637
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.1016.0-pr-106-7a37.zip




