### PR TITLE
VCST-5640: Bind indexed products without building a throwaway JSON DOM

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Binding/CatalogProductBinder.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Binding/CatalogProductBinder.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Serialization;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.Xapi.Core.Binding;
@@ -17,45 +18,56 @@ namespace VirtoCommerce.XCatalog.Core.Binding
 
         public virtual object BindModel(SearchDocument searchDocument)
         {
-            var result = default(CatalogProduct);
-
             if (!searchDocument.TryGetValue(BindingInfo.FieldName, out var obj))
             {
                 // No object in index
-                return result;
+                return null;
             }
 
-            // check if __object document field name contains string or jObject
-            if (obj is string sObj)
+            var result = Deserialize(obj);
+
+            if (result == null)
             {
-                try
-                {
-                    obj = JObject.Parse(sObj);
-                }
-                catch (JsonReaderException)
-                {
-                    return result;
-                }
+                return null;
             }
 
-            if (obj is JObject jobj)
+            var productProperties = result.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+            foreach (var property in productProperties)
             {
-                result = (CatalogProduct)jobj.ToObject(_productType);
+                var binder = property.GetIndexModelBinder();
 
-                var productProperties = result.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
-
-                foreach (var property in productProperties)
+                if (binder != null)
                 {
-                    var binder = property.GetIndexModelBinder();
-
-                    if (binder != null)
-                    {
-                        property.SetValue(result, binder.BindModel(searchDocument));
-                    }
+                    property.SetValue(result, binder.BindModel(searchDocument));
                 }
             }
 
             return result;
+        }
+
+        private static CatalogProduct Deserialize(object obj)
+        {
+            switch (obj)
+            {
+                case string sObj:
+                    try
+                    {
+                        return (CatalogProduct)ProductJsonSerializer.Deserialize(sObj, _productType);
+                    }
+                    // JObject.Parse rejected a payload that was not an object; the direct path reports
+                    // that as a serialization error, so both must stay non-fatal for the whole page.
+                    catch (JsonException)
+                    {
+                        return null;
+                    }
+
+                case JObject jobj:
+                    return (CatalogProduct)jobj.ToObject(_productType);
+
+                default:
+                    return null;
+            }
         }
     }
 }

--- a/src/VirtoCommerce.XCatalog.Core/Binding/MinVariationPriceBinder.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Binding/MinVariationPriceBinder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using VirtoCommerce.CatalogModule.Core.Serialization;
 using VirtoCommerce.PricingModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.Xapi.Core.Binding;
@@ -26,24 +27,34 @@ namespace VirtoCommerce.XCatalog.Core.Binding
             {
                 case Array jArray:
                     {
-                        var jObjects = new List<JObject>();
+                        var indexedPrices = new List<IndexedPrice>();
                         foreach (var sObj in jArray.OfType<string>())
                         {
                             try
                             {
-                                var jObj = JObject.Parse(sObj);
-                                jObjects.Add(jObj);
+                                var indexedPrice = ProductJsonSerializer.Deserialize<IndexedPrice>(sObj);
+
+                                if (indexedPrice != null)
+                                {
+                                    indexedPrices.Add(indexedPrice);
+                                }
                             }
-                            catch (JsonReaderException)
+                            // JObject.Parse rejected a payload that was not an object; the direct path
+                            // reports that as a serialization error, and both must skip only this price.
+                            catch (JsonException)
                             {
                                 // Intentionally left empty
                             }
                         }
 
-                        jObjects = jObjects.Count != 0 ? jObjects : jArray.OfType<JObject>().ToList();
-                        foreach (var jObject in jObjects)
+                        if (indexedPrices.Count == 0)
                         {
-                            AddPrice(result, jObject);
+                            indexedPrices = jArray.OfType<JObject>().Select(x => x.ToObject<IndexedPrice>()).ToList();
+                        }
+
+                        foreach (var indexedPrice in indexedPrices)
+                        {
+                            AddPrice(result, indexedPrice);
                         }
 
                         break;
@@ -51,7 +62,7 @@ namespace VirtoCommerce.XCatalog.Core.Binding
 
                 case JObject jObject:
                     {
-                        AddPrice(result, jObject);
+                        AddPrice(result, jObject.ToObject<IndexedPrice>());
                         break;
                     }
             }
@@ -59,9 +70,8 @@ namespace VirtoCommerce.XCatalog.Core.Binding
             return result;
         }
 
-        private static void AddPrice(List<Price> result, JObject jObject)
+        private static void AddPrice(List<Price> result, IndexedPrice indexedPrice)
         {
-            var indexedPrice = jObject.ToObject<IndexedPrice>();
             result.Add(new Price
             {
                 Currency = indexedPrice.Currency,

--- a/tests/VirtoCommerce.XCatalog.Tests/Binding/CatalogProductBinderTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Binding/CatalogProductBinderTests.cs
@@ -1,0 +1,188 @@
+using System;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Outlines;
+using VirtoCommerce.CatalogModule.Core.Serialization;
+using VirtoCommerce.SearchModule.Core.Model;
+using VirtoCommerce.Seo.Core.Models;
+using VirtoCommerce.XCatalog.Core.Binding;
+using Xunit;
+
+namespace VirtoCommerce.XCatalog.Tests.Binding;
+
+public class CatalogProductBinderTests
+{
+    private const string ObjectFieldName = "__object";
+
+    private readonly CatalogProductBinder _binder = new();
+
+    [Fact]
+    public void BindModel_NoObjectField_ReturnsNull()
+    {
+        var result = _binder.BindModel(new SearchDocument());
+
+        result.Should().BeNull();
+    }
+
+    /// <summary>
+    /// An unusable payload must cost the caller this one product, never the whole result page:
+    /// <c>BindModel</c> runs inside the AutoMapper conversion that maps every document of the page.
+    /// </summary>
+    [Theory]
+    [InlineData("{ this is not json")]
+    [InlineData("")]
+    [InlineData("null")]
+    [InlineData("[]")]
+    [InlineData("[{ \"id\": \"product-id\" }]")]
+    [InlineData("\"a string\"")]
+    [InlineData("123")]
+    public void BindModel_UnusablePayload_ReturnsNull(string json)
+    {
+        var result = _binder.BindModel(Document(json));
+
+        result.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The string branch and the structural branch feed the same product to every consumer;
+    /// only the provider differs in which one it stores.
+    /// </summary>
+    [Fact]
+    public void BindModel_StringPayload_ProducesSameProductAsStructuralPayload()
+    {
+        var json = ProductJsonSerializer.Serialize(CreateProduct());
+
+        var fromString = _binder.BindModel(Document(json));
+        var fromJObject = _binder.BindModel(Document(JObject.Parse(json)));
+
+        fromString.Should().BeEquivalentTo(fromJObject);
+    }
+
+    /// <summary>
+    /// <see cref="PropertyValue.Value"/> is typed <see cref="object"/>, so its runtime type is decided by
+    /// date handling rather than by a contract — the one member where the two branches can disagree.
+    /// </summary>
+    [Theory]
+    [InlineData("2026-08-04T10:20:30Z")]
+    [InlineData("2026-08-04")]
+    [InlineData("not-a-date")]
+    public void BindModel_DateShapedPropertyValue_ResolvesIdenticallyOnBothBranches(string value)
+    {
+        var product = CreateProduct();
+        product.Properties[0].Values[0].Value = value;
+        var json = ProductJsonSerializer.Serialize(product);
+
+        var fromString = _binder.BindModel(Document(json)) as CatalogProduct;
+        var fromJObject = _binder.BindModel(Document(JObject.Parse(json))) as CatalogProduct;
+
+        var boundFromString = fromString.Properties[0].Values[0].Value;
+        var boundFromJObject = fromJObject.Properties[0].Values[0].Value;
+
+        boundFromString.Should().Be(boundFromJObject);
+        boundFromString.GetType().Should().Be(boundFromJObject.GetType());
+    }
+
+    /// <summary>
+    /// Fails on the pre-fix binder, which builds a Newtonsoft DOM and then walks it to produce the
+    /// product — so binding costs strictly more than parsing alone.
+    /// </summary>
+    [Fact]
+    public void BindModel_StringPayload_CostsLessThanParsingItIntoADocument()
+    {
+        const int iterations = 50;
+
+        var json = ProductJsonSerializer.Serialize(CreateProduct());
+        var document = Document(json);
+
+        // Warm up the serializer's contract cache and the reflection caches behind the property-binder loop.
+        _binder.BindModel(document);
+        JObject.Parse(json);
+
+        var parseBytes = Measure(() =>
+        {
+            for (var i = 0; i < iterations; i++)
+            {
+                JObject.Parse(json);
+            }
+        });
+
+        var bindBytes = Measure(() =>
+        {
+            for (var i = 0; i < iterations; i++)
+            {
+                _binder.BindModel(document);
+            }
+        });
+
+        bindBytes.Should().BeLessThan(parseBytes,
+            "binding a serialized payload must not build a throwaway JSON DOM on the way to the product");
+    }
+
+    private static long Measure(Action action)
+    {
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        action();
+
+        return GC.GetAllocatedBytesForCurrentThread() - before;
+    }
+
+    private static SearchDocument Document(object objectFieldValue)
+    {
+        return new SearchDocument { { ObjectFieldName, objectFieldValue } };
+    }
+
+    private static CatalogProduct CreateProduct()
+    {
+        return new CatalogProduct
+        {
+            Id = "product-id",
+            Code = "SKU-1",
+            Name = "Safety gloves",
+            CatalogId = "catalog-id",
+            CategoryId = "category-id",
+            ProductType = "Physical",
+            IsActive = true,
+            IsBuyable = true,
+            StartDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Properties =
+            [
+                new Property
+                {
+                    Id = "property-id",
+                    Name = "Material",
+                    Type = PropertyType.Product,
+                    ValueType = PropertyValueType.ShortText,
+                    Values =
+                    [
+                        new PropertyValue
+                        {
+                            PropertyName = "Material",
+                            ValueType = PropertyValueType.ShortText,
+                            Value = "Nitrile",
+                        },
+                    ],
+                },
+            ],
+            Images =
+            [
+                new Image { Id = "image-id", Url = "/assets/gloves.jpg", SortOrder = 1 },
+            ],
+            SeoInfos =
+            [
+                new SeoInfo { Id = "seo-id", SemanticUrl = "safety-gloves", LanguageCode = "en-US" },
+            ],
+            Outlines =
+            [
+                new Outline
+                {
+                    Items =
+                    [
+                        new OutlineItem { Id = "catalog-id", SeoObjectType = "Catalog" },
+                        new OutlineItem { Id = "category-id", SeoObjectType = "Category" },
+                    ],
+                },
+            ],
+        };
+    }
+}

--- a/tests/VirtoCommerce.XCatalog.Tests/Binding/MinVariationPriceBinderTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Binding/MinVariationPriceBinderTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using VirtoCommerce.CatalogModule.Core.Serialization;
+using VirtoCommerce.PricingModule.Core.Model;
+using VirtoCommerce.SearchModule.Core.Model;
+using VirtoCommerce.XCatalog.Core.Binding;
+using Xunit;
+
+namespace VirtoCommerce.XCatalog.Tests.Binding;
+
+public class MinVariationPriceBinderTests
+{
+    private const string PriceFieldName = "__minvariationprice";
+
+    private readonly MinVariationPriceBinder _binder = new();
+
+    [Fact]
+    public void BindModel_NoPriceField_ReturnsEmpty()
+    {
+        var result = (IList<Price>)_binder.BindModel(new SearchDocument());
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BindModel_MalformedJsonStrings_ReturnsEmpty()
+    {
+        var result = (IList<Price>)_binder.BindModel(Document(new object[] { "{ not json", "also not json" }));
+
+        result.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// One unusable element must cost that price only — the exception would otherwise escape into the
+    /// AutoMapper conversion and fail the whole result page.
+    /// </summary>
+    [Theory]
+    [InlineData("{ not json")]
+    [InlineData("null")]
+    [InlineData("[]")]
+    [InlineData("123")]
+    public void BindModel_UnusableElement_IsSkippedAndTheRestAreBound(string unusable)
+    {
+        var payloads = Serialize(("USD", 10.5m));
+
+        var result = (IList<Price>)_binder.BindModel(Document(new object[] { unusable, payloads[0] }));
+
+        result.Should().ContainSingle().Which.Currency.Should().Be("USD");
+    }
+
+    /// <summary>
+    /// Long-standing behaviour: structural records are a fallback for an array that yielded no price
+    /// from a string, so in a mixed array they are dropped rather than merged.
+    /// </summary>
+    [Fact]
+    public void BindModel_MixedStringAndStructuralArray_BindsTheStringsOnly()
+    {
+        var payloads = Serialize(("USD", 10.5m), ("EUR", 9.25m));
+
+        var result = (IList<Price>)_binder.BindModel(Document(new object[] { payloads[0], JObject.Parse(payloads[1]) }));
+
+        result.Should().ContainSingle().Which.Currency.Should().Be("USD");
+    }
+
+    [Fact]
+    public void BindModel_StringPayloads_ProduceSamePricesAsStructuralPayloads()
+    {
+        var payloads = Serialize(("USD", 10.5m), ("EUR", 9.25m));
+
+        var fromStrings = _binder.BindModel(Document(payloads));
+        var fromJObjects = _binder.BindModel(Document(Array.ConvertAll(payloads, JObject.Parse)));
+
+        fromStrings.Should().BeEquivalentTo(fromJObjects);
+    }
+
+    /// <summary>
+    /// A single structural record is not wrapped in an array by every provider.
+    /// </summary>
+    [Fact]
+    public void BindModel_SingleStructuralRecord_IsBound()
+    {
+        var result = (IList<Price>)_binder.BindModel(Document(JObject.Parse(Serialize(("USD", 10.5m))[0])));
+
+        result.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Currency = "USD", List = 10.5m });
+    }
+
+    /// <summary>
+    /// Structural records are the fallback for an array whose strings all failed to parse; a provider
+    /// storing them must not lose prices because the string branch stopped building a DOM.
+    /// </summary>
+    [Fact]
+    public void BindModel_StructuralRecordsInArray_AreBound()
+    {
+        var payloads = Serialize(("USD", 10.5m), ("EUR", 9.25m));
+
+        var result = (IList<Price>)_binder.BindModel(Document(Array.ConvertAll(payloads, JObject.Parse)));
+
+        result.Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// Fails on the pre-fix binder, which builds a Newtonsoft DOM per price and then converts it —
+    /// so binding costs strictly more than parsing the same payloads alone.
+    /// </summary>
+    [Fact]
+    public void BindModel_StringPayloads_CostLessThanParsingThemIntoDocuments()
+    {
+        const int iterations = 50;
+
+        var payloads = Serialize(("USD", 10.5m), ("EUR", 9.25m), ("GBP", 8.75m));
+        var document = Document(payloads);
+
+        _binder.BindModel(document);
+        Array.ConvertAll(payloads, JObject.Parse);
+
+        var parseBytes = Measure(() =>
+        {
+            for (var i = 0; i < iterations; i++)
+            {
+                Array.ConvertAll(payloads, JObject.Parse);
+            }
+        });
+
+        var bindBytes = Measure(() =>
+        {
+            for (var i = 0; i < iterations; i++)
+            {
+                _binder.BindModel(document);
+            }
+        });
+
+        bindBytes.Should().BeLessThan(parseBytes,
+            "binding serialized prices must not build a throwaway JSON DOM per price");
+    }
+
+    private static long Measure(Action action)
+    {
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        action();
+
+        return GC.GetAllocatedBytesForCurrentThread() - before;
+    }
+
+    private static SearchDocument Document(object priceFieldValue)
+    {
+        return new SearchDocument { { PriceFieldName, priceFieldValue } };
+    }
+
+    private static string[] Serialize(params (string Currency, decimal Value)[] prices)
+    {
+        return Array.ConvertAll(prices, x => ProductJsonSerializer.Serialize(new IndexedPrice
+        {
+            Currency = x.Currency,
+            Value = x.Value,
+        }));
+    }
+}


### PR DESCRIPTION
Resolves [VCST-5640](https://virtocommerce.atlassian.net/browse/VCST-5640).

## The problem

`CatalogProductBinder.BindModel` parsed the indexed `__object` string into a Newtonsoft token tree and then walked that tree once to produce the product. The tree is pure scaffolding — built, read, discarded. `MinVariationPriceBinder` did the same, once per price per document.

The string branch is not an edge case. On Elasticsearch 8, `ElasticSearchResponseBuilder.GetValue` renders any object-kind `JsonElement` through `_ => jsonElement.ToString()`, so `__object` always arrives as a string and the structural branch is never taken. The payload is therefore materialized four times on the read path: the transport's own reader produces elements, those become a `String`, the string becomes a token tree, and the tree becomes the model.

Sampled on the dev cluster to size it: `__object` is **20 482 characters of a 26 081-character document — 78.5%** — and its mapping is an object with indexing disabled, stored in `_source` and never indexed. So the discarded tree was built over roughly 20 KB of JSON per product, per consumer.

Nothing on the path memoizes the materialized product — the caches in this area cache the *document*, so every cache hit still re-ran the parse. That is why an A/B of two search-caching strategies left the top of the allocation profile unmoved: caching removes the round trip and leaves the parse behind it.

Measured on a deployment under a cart-and-order load profile with an allocation trace, the Newtonsoft DOM accounted for 21.2% of sampled allocations (8188 MB of 38.55 GB) and about 3.2% of on-CPU active time, under the stack `JObject.Parse <- CatalogProductBinder.BindModel <- AutoMapper <- SearchProductQueryHandler.ConvertProducts`.

## Why direct deserialization is equivalent here

The usual objection is that the tree is needed for polymorphic type resolution. On this path it is not:

- `PolymorphJsonConverter` is registered only into the MVC serializer settings, and `JsonConvert.DefaultSettings` is set nowhere in the platform or in these modules — so `JObject.ToObject(type)` already ran with a bare default serializer, no converters and no discriminators.
- The stored payload carries no type discriminators; it is written with `TypeNameHandling.None`.
- The root type is resolved explicitly and once, into a static field.

So nested factory overrides were already not honoured here, and equivalence holds by construction rather than by hope.

`IndexDocumentHelper.GetObjectFieldValue<T>` in vc-module-catalog is the shipped precedent this change mirrors: a switch whose string arm goes straight through `ProductJsonSerializer` and builds no tree. The structural branch is kept for providers that store `__object` as an object.

## The guard widens from `JsonReaderException` to `JsonException`

`JObject.Parse` rejected valid-JSON-that-is-not-an-object (`[]`, `123`, a bare string) as a *reader* error, so the old `catch` absorbed it and the binder returned no product. Deserializing straight into the target contract reports the same input as a *serialization* error instead.

Left narrowed, that input would escape `BindModel` into the AutoMapper conversion and fail the mapping of the whole result page rather than dropping the single document — and in `MinVariationPriceBinder` the `catch` sits inside the per-element loop, so it would also defeat the skip that exists to survive one bad price. Widening restores exactly the pre-change coverage.

## Verification

The allocation tests assert that binding a payload costs **less than merely parsing it into a document** — an invariant that is false while a tree is built on the way to the model and true once it is not. Both were confirmed red against the unmodified binders before the change, and the guard tests were confirmed red against the narrowed `catch`. `GC.GetAllocatedBytesForCurrentThread` is exact per-thread accounting, and the figures reproduced byte-identically across repeated runs.

Per bound document, allocations fall from 32.2 KB to 6.9 KB for `CatalogProductBinder`, and from 4.2 KB to 2.7 KB for a three-price `MinVariationPriceBinder` document. The filtered unit suite is green.

The price-binder win is the smaller one by construction: a single indexed price is tiny, so the `JsonTextReader` buffer dominates what the discarded tree used to cost.

## Not covered by this change

- No BenchmarkDotNet arm. The `VirtoCommerce.XCatalog.Benchmark` project arrives with VCST-5637 (#106); a `MemoryDiagnoser` benchmark over `BindModel` belongs there once that merges.
- The property-binder loop is an extension seam for a downstream module that overrides `CatalogProduct` with `[BindIndexField]` properties. Its preservation is reviewed structurally, not tested: `_productType` is a `static readonly` captured once per process, so a factory-override test would depend on execution order.
- `CategoryBinder` still handles only the structural branch. Measured against the dev cluster, category documents carry no `__object` at all — the binder returns at its `TryGetValue` guard and never reaches the missing branch — so adding one would change nothing observable today. Left alone deliberately.


[VCST-5640]: https://virtocommerce.atlassian.net/browse/VCST-5640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every search hit’s product/price mapping; behavior must stay equivalent for bad index data so one bad document does not break a full result page.
> 
> **Overview**
> **Search index binders** now deserialize `__object` and `__minvariationprice` string payloads with `ProductJsonSerializer` instead of `JObject.Parse` plus `ToObject`, avoiding a discarded Newtonsoft DOM on the hot path (notably Elasticsearch 8, where `__object` is always a string).
> 
> `CatalogProductBinder` moves deserialization into a `Deserialize` helper and still runs index property binders after a successful product; bad or non-object JSON returns `null` for that document only. `MinVariationPriceBinder` deserializes each string to `IndexedPrice` directly and keeps the `JObject` fallback when no string prices parse.
> 
> **Error handling** widens catches from `JsonReaderException` to `JsonException` so invalid-but-parseable JSON (arrays, scalars, `null`) stays non-fatal and does not fail an entire AutoMapper search page.
> 
> **Tests** add coverage for unusable payloads, string vs structural equivalence, mixed price arrays, and allocation checks that binding uses less memory than parsing into documents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fba03d20ec140b660ed18b0e381a7cf8b458a545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.1016.0-pr-107-fba0.zip