### PR TITLE
VCST-5689: batch the variations resolver instead of one search per master

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -497,7 +497,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             // "isActive" is requested for both fields although only the variations field filters on it, so that
             // the two agree on a key.
             var loadedFields = includeFields.ToList();
-            if (!loadedFields.Contains("isActive"))
+            if (!loadedFields.Contains("isActive", StringComparer.OrdinalIgnoreCase))
             {
                 loadedFields.Add("isActive");
             }

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -29,6 +29,8 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 {
     public class ProductType : ExtendableGraphType<ExpProduct>
     {
+        private readonly IDataLoaderContextAccessor _dataLoader;
+
         /// <example>
         ///{
         ///    product(id: "f1b26974b7634abaa0900e575a99476f")
@@ -67,6 +69,8 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
         /// </example>
         public ProductType(IDataLoaderContextAccessor dataLoader)
         {
+            _dataLoader = dataLoader;
+
             Name = "Product";
             Description = "Products are the sellable goods in an e-commerce project.";
 

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -463,7 +463,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             // asked for nothing and must not be served, while a caller selecting only __typename has asked for
             // something the master's document can answer.
             if (includeFields.Count > 0 &&
-                dataFields.All(x => _masterAnswerableVariationFields.Contains(x, StringComparer.OrdinalIgnoreCase)))
+                dataFields.All(x => _masterAnswerableVariationFields.Contains(x)))
             {
                 // The stored id list is already active-only: the indexer writes an id into the master's document
                 // only inside its IsActive branch, and any variation change forces a full reindex of the master.
@@ -507,7 +507,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             // "isActive" is requested for both fields although only the variations field filters on it, so that
             // the two agree on a key.
             var loadedFields = includeFields.ToList();
-            if (!loadedFields.Contains("isActive", StringComparer.OrdinalIgnoreCase))
+            if (!loadedFields.Contains("isActive"))
             {
                 loadedFields.Add("isActive");
             }
@@ -515,6 +515,10 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             // The field set is part of the key, not just of the query: IncludeFields is derived from
             // context.SubFields, so two aliases selecting different subfields would otherwise share one loader
             // and whichever registered second would be served an under-selected result.
+            // The comparer here is the one that is not redundant. Equality on string defaults to ordinal, but
+            // ORDERING defaults to the current culture - and sibling nodes of one request can be resolved on
+            // threads whose culture differs, which would sort the same field set two ways, produce two keys and
+            // quietly cost the second search.
             var loaderKey = $"product_variations_{string.Join(',', loadedFields.OrderBy(x => x, StringComparer.Ordinal))}";
 
             return _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>(

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -274,20 +274,15 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             ExtendableField<VariationType>(
                 "masterVariation",
                 resolve: context =>
-                {
-                    if (string.IsNullOrEmpty(context.Source.IndexedProduct.MainProductId))
-                    {
-                        return null;
-                    }
+                    // A main product is not subject to the variations field's active-only contract.
+                    ResolveVariations(context, [context.Source.IndexedProduct.MainProductId], onlyActive: false)
+                        .Then(variations => variations.FirstOrDefault()));
 
-                    // No IsActive filter here: a main product is not subject to the variations field's active-only contract.
-                    return LoadVariations(context, [context.Source.IndexedProduct.MainProductId], onlyActive: false)
-                        .Then(variations => variations.FirstOrDefault());
-                });
-
+#pragma warning disable VC0015 // Type or member is obsolete
             ExtendableFieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<VariationType>>>>(
                 "variations",
                 resolve: ResolveVariationsFieldAsync);
+#pragma warning restore VC0015 // Type or member is obsolete
 
             Field<NonNullGraphType<BooleanGraphType>, bool>("hasVariations")
                 .Resolve(context =>
@@ -428,18 +423,19 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             return brandName?.ToString();
         }
 
+        [Obsolete("Use ResolveVariations.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
         protected virtual Task<object> ResolveVariationsFieldAsync(IResolveFieldContext<ExpProduct> context)
         {
-            if (context.Source.IndexedVariationIds.IsNullOrEmpty())
-            {
-                return Task.FromResult<object>(new List<ExpVariation>());
-            }
-
-            return Task.FromResult<object>(LoadVariations(context, context.Source.IndexedVariationIds, onlyActive: true));
+            return Task.FromResult<object>(ResolveVariations(context, context.Source.IndexedVariationIds, onlyActive: true));
         }
 
-        private IDataLoaderResult<IEnumerable<ExpVariation>> LoadVariations(IResolveFieldContext context, IEnumerable<string> variationIds, bool onlyActive)
+        protected virtual IDataLoaderResult<IList<ExpVariation>> ResolveVariations(IResolveFieldContext context, IList<string> variationIds, bool onlyActive)
         {
+            if (variationIds.IsNullOrEmpty() || variationIds.All(string.IsNullOrEmpty))
+            {
+                return new DataLoaderResult<IList<ExpVariation>>([]);
+            }
+
             var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
 
             // Always request isActive, so that filtered and unfiltered requests share the same key.
@@ -466,9 +462,10 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             return loader
                 .LoadAsync(variationIds)
-                .Then(products => products
+                .Then(products => (IList<ExpVariation>)products
                     .Where(x => x is not null && (!onlyActive || x.IndexedProduct?.IsActive == true))
-                    .Select(x => new ExpVariation(x)));
+                    .Select(x => new ExpVariation(x))
+                    .ToList());
         }
 
         private static async Task<object> ResolveVideosConnectionAsync(IResolveConnectionContext<ExpProduct> context)

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -273,10 +273,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             ExtendableField<VariationType>(
                 "masterVariation",
-                resolve: context =>
-                    // A main product is not subject to the variations field's active-only contract.
-                    ResolveVariations(context, [context.Source.IndexedProduct.MainProductId], onlyActive: false)
-                        .Then(variations => variations.FirstOrDefault()));
+                resolve: ResolveMasterVariation);
 
 #pragma warning disable VC0015 // Type or member is obsolete
             ExtendableFieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<VariationType>>>>(
@@ -423,30 +420,56 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             return brandName?.ToString();
         }
 
+        protected virtual IDataLoaderResult<ExpVariation> ResolveMasterVariation(IResolveFieldContext<ExpProduct> context)
+        {
+            var id = context.Source.IndexedProduct.MainProductId;
+
+            if (string.IsNullOrEmpty(id))
+            {
+                return new DataLoaderResult<ExpVariation>((ExpVariation)null);
+            }
+
+            return GetVariationLoader(context)
+                .LoadAsync(id)
+                .Then(product => product is null ? null : new ExpVariation(product));
+        }
+
         [Obsolete("Use ResolveVariations.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
         protected virtual Task<object> ResolveVariationsFieldAsync(IResolveFieldContext<ExpProduct> context)
         {
-            return Task.FromResult<object>(ResolveVariations(context, context.Source.IndexedVariationIds, onlyActive: true));
+            return Task.FromResult<object>(ResolveVariations(context));
         }
 
-        protected virtual IDataLoaderResult<IList<ExpVariation>> ResolveVariations(IResolveFieldContext context, IList<string> variationIds, bool onlyActive)
+        protected virtual IDataLoaderResult<IList<ExpVariation>> ResolveVariations(IResolveFieldContext<ExpProduct> context)
         {
-            if (variationIds.IsNullOrEmpty() || variationIds.All(string.IsNullOrEmpty))
+            var ids = context.Source.IndexedVariationIds;
+
+            if (ids.IsNullOrEmpty())
             {
                 return new DataLoaderResult<IList<ExpVariation>>([]);
             }
 
+            // Include 'isActive' field to filter out inactive variations
+            return GetVariationLoader(context, includeIsActiveField: true)
+                .LoadAsync(ids)
+                .Then(IList<ExpVariation> (products) => products
+                    .Where(x => x?.IndexedProduct?.IsActive == true)
+                    .Select(x => new ExpVariation(x))
+                    .ToList());
+        }
+
+        private IDataLoader<string, ExpProduct> GetVariationLoader(IResolveFieldContext context, bool includeIsActiveField = false)
+        {
             var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
 
-            // Always request isActive, so that filtered and unfiltered requests share the same key.
-            if (!includeFields.Contains("isActive"))
+            if (includeIsActiveField && !includeFields.Contains("isActive"))
             {
                 includeFields.Add("isActive");
             }
 
             var loaderKey = $"product_variations_{string.Join(',', includeFields.OrderBy(x => x, StringComparer.Ordinal))}";
 
-            var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>(
+            return _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>(
                 loaderKey,
                 async ids =>
                 {
@@ -459,13 +482,6 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                     return response.Products.ToDictionary(x => x.Id);
                 },
                 maxBatchSize: _maxVariationsBatchSize);
-
-            return loader
-                .LoadAsync(variationIds)
-                .Then(IList<ExpVariation> (products) => products
-                    .Where(x => x is not null && (!onlyActive || x.IndexedProduct?.IsActive == true))
-                    .Select(x => new ExpVariation(x))
-                    .ToList());
         }
 
         private static async Task<object> ResolveVideosConnectionAsync(IResolveConnectionContext<ExpProduct> context)

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -462,7 +462,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             return loader
                 .LoadAsync(variationIds)
-                .Then(products => (IList<ExpVariation>)products
+                .Then(IList<ExpVariation> (products) => products
                     .Where(x => x is not null && (!onlyActive || x.IndexedProduct?.IsActive == true))
                     .Select(x => new ExpVariation(x))
                     .ToList());

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -30,11 +30,6 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
     public class ProductType : ExtendableGraphType<ExpProduct>
     {
         private const int _maxVariationsBatchSize = 200;
-        private const string _typeNameMetaField = "__typename";
-
-        // Every name added here is one more selection whose active flag starts coming from the master's document
-        // instead of the variation's own - hence a named set rather than a projection rule.
-        private static readonly string[] _indexedVariationFields = ["id"];
 
         private readonly IDataLoaderContextAccessor _dataLoader;
 
@@ -450,26 +445,6 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             }
 
             var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
-
-            // Clients that normalize a cache add __typename to every selection set, so counting it as a data
-            // field would keep the gate below from ever firing.
-            var dataFields = includeFields.Where(x => x != _typeNameMetaField).ToList();
-
-            if (includeFields.Count > 0 && dataFields.All(x => _indexedVariationFields.Contains(x)))
-            {
-                // The skipped filter read the variation's own index document, not the database. The indexer
-                // writes an id into the master's document only inside its IsActive branch - so the stored list is
-                // already active-only, and nothing here goes from live to stale.
-                return context.Source.IndexedVariationIds
-                    .Select(id =>
-                    {
-                        var indexedProduct = AbstractTypeFactory<CatalogProduct>.TryCreateInstance();
-                        indexedProduct.Id = id;
-
-                        return new ExpVariation(new ExpProduct { IndexedProduct = indexedProduct });
-                    })
-                    .ToList();
-            }
 
             return GetVariationLoader(context, includeFields)
                 .LoadAsync(context.Source.IndexedVariationIds)

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -29,6 +29,8 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 {
     public class ProductType : ExtendableGraphType<ExpProduct>
     {
+        private const int MaxVariationsBatchSize = 200;
+
         private readonly IDataLoaderContextAccessor _dataLoader;
 
         /// <example>
@@ -430,26 +432,51 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             return brandName?.ToString();
         }
 
-        protected virtual async Task<object> ResolveVariationsFieldAsync(IResolveFieldContext<ExpProduct> context)
+        protected virtual Task<object> ResolveVariationsFieldAsync(IResolveFieldContext<ExpProduct> context)
         {
             if (context.Source.IndexedVariationIds.IsNullOrEmpty())
             {
-                return new List<ExpVariation>();
+                return Task.FromResult<object>(new List<ExpVariation>());
             }
 
-            var query = context.GetCatalogQuery<LoadProductsQuery>();
-            query.ObjectIds = context.Source.IndexedVariationIds;
-            query.IncludeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
+            var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
 
             // Include "isActive" field to filter out inactive variations
-            if (!query.IncludeFields.Contains("isActive"))
+            if (!includeFields.Contains("isActive"))
             {
-                query.IncludeFields.Add("isActive");
+                includeFields.Add("isActive");
             }
 
-            var response = await context.GetMediator().Send(query);
+            // The field set is part of the key, not just of the query: IncludeFields is derived from
+            // context.SubFields, so two aliases of this field selecting different subfields would otherwise
+            // share one loader and whichever registered second would be served an under-selected result.
+            var loaderKey = $"product_variations_{string.Join(',', includeFields.OrderBy(x => x, StringComparer.Ordinal))}";
 
-            return response.Products.Where(x => x.IndexedProduct?.IsActive == true).Select(expProduct => new ExpVariation(expProduct));
+            var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>(
+                loaderKey,
+                async ids =>
+                {
+                    var query = context.GetCatalogQuery<LoadProductsQuery>();
+                    query.ObjectIds = ids.ToList();
+                    query.IncludeFields = includeFields;
+
+                    var response = await context.GetMediator().Send(query);
+
+                    return response.Products.ToDictionary(x => x.Id);
+                },
+                // Caps the keys handed to one fetch, so a page of masters carrying many variations each cannot
+                // turn N moderate searches into one oversized peak of the same total size.
+                maxBatchSize: MaxVariationsBatchSize);
+
+            // Returned, never awaited: awaiting here dispatches one batch per node and restores the N sends.
+            // Task.FromResult is required rather than decoration - Then returns IDataLoaderResult<T>, not a
+            // Task, so returning it bare from a Task<object> method does not compile.
+            return Task.FromResult<object>(loader
+                .LoadAsync(context.Source.IndexedVariationIds)
+                .Then(products => products
+                    .Where(x => x?.IndexedProduct?.IsActive == true)
+                    .Select(x => new ExpVariation(x))
+                    .ToList()));
         }
 
         private static async Task<object> ResolveVideosConnectionAsync(IResolveConnectionContext<ExpProduct> context)

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -29,12 +29,12 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 {
     public class ProductType : ExtendableGraphType<ExpProduct>
     {
-        private const int MaxVariationsBatchSize = 200;
-        private const string TypeNameMetaField = "__typename";
+        private const int _maxVariationsBatchSize = 200;
+        private const string _typeNameMetaField = "__typename";
 
         // Every name added here is one more selection whose active flag starts coming from the master's document
         // instead of the variation's own - hence a named set rather than a projection rule.
-        private static readonly string[] _masterAnswerableVariationFields = ["id"];
+        private static readonly string[] _indexedVariationFields = ["id"];
 
         private readonly IDataLoaderContextAccessor _dataLoader;
 
@@ -439,61 +439,55 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
         protected virtual Task<object> ResolveVariationsFieldAsync(IResolveFieldContext<ExpProduct> context)
         {
+            return Task.FromResult(ResolveVariationsField(context));
+        }
+
+        private object ResolveVariationsField(IResolveFieldContext<ExpProduct> context)
+        {
             if (context.Source.IndexedVariationIds.IsNullOrEmpty())
             {
-                return Task.FromResult<object>(new List<ExpVariation>());
+                return new List<ExpVariation>();
             }
 
             var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
 
-            // Clients that normalise a cache add __typename to every selection set, so counting it as a data
+            // Clients that normalize a cache add __typename to every selection set, so counting it as a data
             // field would keep the gate below from ever firing.
-            var dataFields = includeFields.Where(x => x != TypeNameMetaField).ToList();
+            var dataFields = includeFields.Where(x => x != _typeNameMetaField).ToList();
 
-            if (includeFields.Count > 0 &&
-                dataFields.All(x => _masterAnswerableVariationFields.Contains(x)))
+            if (includeFields.Count > 0 && dataFields.All(x => _indexedVariationFields.Contains(x)))
             {
-                // The skipped filter read the variation's own index document, not the database, and the indexer
+                // The skipped filter read the variation's own index document, not the database. The indexer
                 // writes an id into the master's document only inside its IsActive branch - so the stored list is
-                // already active-only and nothing here goes from live to stale.
-                return Task.FromResult<object>(context.Source.IndexedVariationIds
+                // already active-only, and nothing here goes from live to stale.
+                return context.Source.IndexedVariationIds
                     .Select(id =>
                     {
-                        // Downstream schemas cast IndexedProduct to their own derived type, which a base instance
-                        // built with new would fail.
                         var indexedProduct = AbstractTypeFactory<CatalogProduct>.TryCreateInstance();
                         indexedProduct.Id = id;
 
                         return new ExpVariation(new ExpProduct { IndexedProduct = indexedProduct });
                     })
-                    .ToList());
+                    .ToList();
             }
 
-            var loader = GetVariationLoader(context, includeFields);
-
-            return Task.FromResult<object>(loader
+            return GetVariationLoader(context, includeFields)
                 .LoadAsync(context.Source.IndexedVariationIds)
                 .Then(products => products
                     .Where(x => x?.IndexedProduct?.IsActive == true)
                     .Select(x => new ExpVariation(x))
-                    .ToList()));
+                    .ToList());
         }
 
-        // The key is composed here rather than by each caller: two call sites composing it separately drift into
-        // two loaders, and the page pays the second search with nothing failing.
-        private IDataLoader<string, ExpProduct> GetVariationLoader(IResolveFieldContext context, IList<string> includeFields)
+        private IDataLoader<string, ExpProduct> GetVariationLoader(IResolveFieldContext context, List<string> includeFields)
         {
-            // Requested for both fields although only the variations field filters on it, so the two agree on a key.
-            var loadedFields = includeFields.ToList();
-            if (!loadedFields.Contains("isActive"))
+            // Requested for both fields, although only the variations field filters on it, so the two agree on a key.
+            if (!includeFields.Contains("isActive"))
             {
-                loadedFields.Add("isActive");
+                includeFields.Add("isActive");
             }
 
-            // Drop the field set from the key and two aliases selecting different subfields share one loader,
-            // serving the second an under-selected result. Ordinal because ordering, unlike equality, otherwise
-            // follows the thread's culture.
-            var loaderKey = $"product_variations_{string.Join(',', loadedFields.OrderBy(x => x, StringComparer.Ordinal))}";
+            var loaderKey = $"product_variations_{string.Join(',', includeFields.OrderBy(x => x, StringComparer.Ordinal))}";
 
             return _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>(
                 loaderKey,
@@ -501,13 +495,13 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                 {
                     var query = context.GetCatalogQuery<LoadProductsQuery>();
                     query.ObjectIds = ids.ToList();
-                    query.IncludeFields = loadedFields;
+                    query.IncludeFields = includeFields;
 
                     var response = await context.GetMediator().Send(query);
 
                     return response.Products.ToDictionary(x => x.Id);
                 },
-                maxBatchSize: MaxVariationsBatchSize);
+                maxBatchSize: _maxVariationsBatchSize);
         }
 
         private static async Task<object> ResolveVideosConnectionAsync(IResolveConnectionContext<ExpProduct> context)

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -31,6 +31,12 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
     {
         private const int MaxVariationsBatchSize = 200;
 
+        // Fields the master's own indexed document can answer without loading the variation. Deliberately a
+        // named set rather than a general projection: every addition here changes which selections switch to
+        // reading the active flag from the master's document instead of the variation's own, so it must stay
+        // auditable.
+        private static readonly string[] _masterAnswerableVariationFields = ["id"];
+
         private readonly IDataLoaderContextAccessor _dataLoader;
 
         /// <example>
@@ -443,6 +449,29 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             }
 
             var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
+
+            // An empty selection is not a subset to serve from the index - it is a caller asking for nothing -
+            // so the Count > 0 guard keeps it off this path.
+            if (includeFields.Count > 0 &&
+                includeFields.All(x => _masterAnswerableVariationFields.Contains(x, StringComparer.OrdinalIgnoreCase)))
+            {
+                // The stored id list is already active-only: the indexer writes an id into the master's document
+                // only inside its IsActive branch, and any variation change forces a full reindex of the master.
+                // The filter this skips read the variation's own index document, not the database - LoadProductsQuery
+                // is served by ISearchProvider.SearchAsync - so no live-to-stale transition happens here.
+                return Task.FromResult<object>(context.Source.IndexedVariationIds
+                    .Select(id =>
+                    {
+                        // Through the factory, not new: CatalogProduct is an overridable type, and downstream
+                        // schemas cast IndexedProduct to their own derived type. A synthetic base instance is the
+                        // one value in the system that would fail such a cast.
+                        var indexedProduct = AbstractTypeFactory<CatalogProduct>.TryCreateInstance();
+                        indexedProduct.Id = id;
+
+                        return new ExpVariation(new ExpProduct { IndexedProduct = indexedProduct });
+                    })
+                    .ToList());
+            }
 
             var loader = GetVariationLoader(context, includeFields);
 

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -32,10 +32,8 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
         private const int MaxVariationsBatchSize = 200;
         private const string TypeNameMetaField = "__typename";
 
-        // Fields the master's own indexed document can answer without loading the variation. Deliberately a
-        // named set rather than a general projection: every addition here changes which selections switch to
-        // reading the active flag from the master's document instead of the variation's own, so it must stay
-        // auditable.
+        // Every name added here is one more selection whose active flag starts coming from the master's document
+        // instead of the variation's own - hence a named set rather than a projection rule.
         private static readonly string[] _masterAnswerableVariationFields = ["id"];
 
         private readonly IDataLoaderContextAccessor _dataLoader;
@@ -278,25 +276,22 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             };
             AddField(brandField);
 
-            ExtendableFieldAsync<VariationType>(
+            ExtendableField<VariationType>(
                 "masterVariation",
                 resolve: context =>
                 {
                     if (string.IsNullOrEmpty(context.Source.IndexedProduct.MainProductId))
                     {
-                        return Task.FromResult<object>(null);
+                        return null;
                     }
 
-                    var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
+                    // No IsActive filter here: a master product is not a variation and is not subject to the
+                    // variations field's active-only contract.
+                    var loader = GetVariationLoader(context, context.SubFields.Values.GetAllNodesPaths(context).ToList());
 
-                    // Deliberately no IsActive filter on the result: a master product is not a variation and is
-                    // not subject to the variations field's active-only contract.
-                    var loader = GetVariationLoader(context, includeFields);
-
-                    // Returned, never awaited - see the matching comment on ResolveVariationsFieldAsync.
-                    return Task.FromResult<object>(loader
+                    return loader
                         .LoadAsync(context.Source.IndexedProduct.MainProductId)
-                        .Then(product => product is null ? null : new ExpVariation(product)));
+                        .Then(product => product is null ? null : new ExpVariation(product));
                 });
 
             ExtendableFieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<VariationType>>>>(
@@ -451,30 +446,21 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
 
-            // __typename is resolved from the schema and depends on no data, so a selection carrying it needs
-            // exactly what the same selection without it needs. Excluding it widens nothing: the spec reserves
-            // the __ prefix for introspection and graphql-dotnet rejects any other name that uses it when the
-            // schema is built, and of the three meta-fields only __typename is reachable on a nested field -
-            // __schema and __type exist on the root query type alone. Leaving it in would matter: clients that
-            // normalise a cache add __typename to every selection set, so the gate below would never fire.
+            // Clients that normalise a cache add __typename to every selection set, so counting it as a data
+            // field would keep the gate below from ever firing.
             var dataFields = includeFields.Where(x => x != TypeNameMetaField).ToList();
 
-            // Count is read off the raw selection, not the filtered one: a caller selecting nothing at all has
-            // asked for nothing and must not be served, while a caller selecting only __typename has asked for
-            // something the master's document can answer.
             if (includeFields.Count > 0 &&
                 dataFields.All(x => _masterAnswerableVariationFields.Contains(x)))
             {
-                // The stored id list is already active-only: the indexer writes an id into the master's document
-                // only inside its IsActive branch, and any variation change forces a full reindex of the master.
-                // The filter this skips read the variation's own index document, not the database - LoadProductsQuery
-                // is served by ISearchProvider.SearchAsync - so no live-to-stale transition happens here.
+                // The skipped filter read the variation's own index document, not the database, and the indexer
+                // writes an id into the master's document only inside its IsActive branch - so the stored list is
+                // already active-only and nothing here goes from live to stale.
                 return Task.FromResult<object>(context.Source.IndexedVariationIds
                     .Select(id =>
                     {
-                        // Through the factory, not new: CatalogProduct is an overridable type, and downstream
-                        // schemas cast IndexedProduct to their own derived type. A synthetic base instance is the
-                        // one value in the system that would fail such a cast.
+                        // Downstream schemas cast IndexedProduct to their own derived type, which a base instance
+                        // built with new would fail.
                         var indexedProduct = AbstractTypeFactory<CatalogProduct>.TryCreateInstance();
                         indexedProduct.Id = id;
 
@@ -485,9 +471,6 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             var loader = GetVariationLoader(context, includeFields);
 
-            // Returned, never awaited: awaiting here dispatches one batch per node and restores the N sends.
-            // Task.FromResult is required rather than decoration - Then returns IDataLoaderResult<T>, not a
-            // Task, so returning it bare from a Task<object> method does not compile.
             return Task.FromResult<object>(loader
                 .LoadAsync(context.Source.IndexedVariationIds)
                 .Then(products => products
@@ -496,29 +479,20 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                     .ToList()));
         }
 
-        // Shared by the variations and masterVariation resolvers so both fold onto the same loader when a page
-        // renders both fields. GetOrAddBatchLoader resolves a key through ConcurrentDictionary.GetOrAdd, so the
-        // first registration for a key wins - one definition removes the question of whether two independently
-        // written fetch funcs stay semantically equivalent as either one changes later. The key is built here
-        // rather than passed in for the same reason: two call sites composing it separately would drift apart
-        // into two loaders, which costs the second search back with nothing failing.
+        // The key is composed here rather than by each caller: two call sites composing it separately drift into
+        // two loaders, and the page pays the second search with nothing failing.
         private IDataLoader<string, ExpProduct> GetVariationLoader(IResolveFieldContext context, IList<string> includeFields)
         {
-            // "isActive" is requested for both fields although only the variations field filters on it, so that
-            // the two agree on a key.
+            // Requested for both fields although only the variations field filters on it, so the two agree on a key.
             var loadedFields = includeFields.ToList();
             if (!loadedFields.Contains("isActive"))
             {
                 loadedFields.Add("isActive");
             }
 
-            // The field set is part of the key, not just of the query: IncludeFields is derived from
-            // context.SubFields, so two aliases selecting different subfields would otherwise share one loader
-            // and whichever registered second would be served an under-selected result.
-            // The comparer here is the one that is not redundant. Equality on string defaults to ordinal, but
-            // ORDERING defaults to the current culture - and sibling nodes of one request can be resolved on
-            // threads whose culture differs, which would sort the same field set two ways, produce two keys and
-            // quietly cost the second search.
+            // Drop the field set from the key and two aliases selecting different subfields share one loader,
+            // serving the second an under-selected result. Ordinal because ordering, unlike equality, otherwise
+            // follows the thread's culture.
             var loaderKey = $"product_variations_{string.Join(',', loadedFields.OrderBy(x => x, StringComparer.Ordinal))}";
 
             return _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>(
@@ -533,8 +507,6 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
                     return response.Products.ToDictionary(x => x.Id);
                 },
-                // Caps the keys handed to one fetch, so a page of masters carrying many variations each cannot
-                // turn N moderate searches into one oversized peak of the same total size.
                 maxBatchSize: MaxVariationsBatchSize);
         }
 

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -273,20 +273,23 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             ExtendableFieldAsync<VariationType>(
                 "masterVariation",
-                resolve: async context =>
+                resolve: context =>
                 {
                     if (string.IsNullOrEmpty(context.Source.IndexedProduct.MainProductId))
                     {
-                        return null;
+                        return Task.FromResult<object>(null);
                     }
 
-                    var query = context.GetCatalogQuery<LoadProductsQuery>();
-                    query.ObjectIds = new[] { context.Source.IndexedProduct.MainProductId };
-                    query.IncludeFields = context.SubFields.Values.GetAllNodesPaths(context).ToArray();
+                    var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
 
-                    var response = await context.GetMediator().Send(query);
+                    // Deliberately no IsActive filter on the result: a master product is not a variation and is
+                    // not subject to the variations field's active-only contract.
+                    var loader = GetVariationLoader(context, includeFields);
 
-                    return response.Products.Select(expProduct => new ExpVariation(expProduct)).FirstOrDefault();
+                    // Returned, never awaited - see the matching comment on ResolveVariationsFieldAsync.
+                    return Task.FromResult<object>(loader
+                        .LoadAsync(context.Source.IndexedProduct.MainProductId)
+                        .Then(product => product is null ? null : new ExpVariation(product)));
                 });
 
             ExtendableFieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<VariationType>>>>(
@@ -441,32 +444,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
 
-            // Include "isActive" field to filter out inactive variations
-            if (!includeFields.Contains("isActive"))
-            {
-                includeFields.Add("isActive");
-            }
-
-            // The field set is part of the key, not just of the query: IncludeFields is derived from
-            // context.SubFields, so two aliases of this field selecting different subfields would otherwise
-            // share one loader and whichever registered second would be served an under-selected result.
-            var loaderKey = $"product_variations_{string.Join(',', includeFields.OrderBy(x => x, StringComparer.Ordinal))}";
-
-            var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>(
-                loaderKey,
-                async ids =>
-                {
-                    var query = context.GetCatalogQuery<LoadProductsQuery>();
-                    query.ObjectIds = ids.ToList();
-                    query.IncludeFields = includeFields;
-
-                    var response = await context.GetMediator().Send(query);
-
-                    return response.Products.ToDictionary(x => x.Id);
-                },
-                // Caps the keys handed to one fetch, so a page of masters carrying many variations each cannot
-                // turn N moderate searches into one oversized peak of the same total size.
-                maxBatchSize: MaxVariationsBatchSize);
+            var loader = GetVariationLoader(context, includeFields);
 
             // Returned, never awaited: awaiting here dispatches one batch per node and restores the N sends.
             // Task.FromResult is required rather than decoration - Then returns IDataLoaderResult<T>, not a
@@ -477,6 +455,44 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                     .Where(x => x?.IndexedProduct?.IsActive == true)
                     .Select(x => new ExpVariation(x))
                     .ToList()));
+        }
+
+        // Shared by the variations and masterVariation resolvers so both fold onto the same loader when a page
+        // renders both fields. GetOrAddBatchLoader resolves a key through ConcurrentDictionary.GetOrAdd, so the
+        // first registration for a key wins - one definition removes the question of whether two independently
+        // written fetch funcs stay semantically equivalent as either one changes later. The key is built here
+        // rather than passed in for the same reason: two call sites composing it separately would drift apart
+        // into two loaders, which costs the second search back with nothing failing.
+        private IDataLoader<string, ExpProduct> GetVariationLoader(IResolveFieldContext context, IList<string> includeFields)
+        {
+            // "isActive" is requested for both fields although only the variations field filters on it, so that
+            // the two agree on a key.
+            var loadedFields = includeFields.ToList();
+            if (!loadedFields.Contains("isActive"))
+            {
+                loadedFields.Add("isActive");
+            }
+
+            // The field set is part of the key, not just of the query: IncludeFields is derived from
+            // context.SubFields, so two aliases selecting different subfields would otherwise share one loader
+            // and whichever registered second would be served an under-selected result.
+            var loaderKey = $"product_variations_{string.Join(',', loadedFields.OrderBy(x => x, StringComparer.Ordinal))}";
+
+            return _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>(
+                loaderKey,
+                async ids =>
+                {
+                    var query = context.GetCatalogQuery<LoadProductsQuery>();
+                    query.ObjectIds = ids.ToList();
+                    query.IncludeFields = loadedFields;
+
+                    var response = await context.GetMediator().Send(query);
+
+                    return response.Products.ToDictionary(x => x.Id);
+                },
+                // Caps the keys handed to one fetch, so a page of masters carrying many variations each cannot
+                // turn N moderate searches into one oversized peak of the same total size.
+                maxBatchSize: MaxVariationsBatchSize);
         }
 
         private static async Task<object> ResolveVideosConnectionAsync(IResolveConnectionContext<ExpProduct> context)

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -30,6 +30,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
     public class ProductType : ExtendableGraphType<ExpProduct>
     {
         private const int MaxVariationsBatchSize = 200;
+        private const string TypeNameMetaField = "__typename";
 
         // Fields the master's own indexed document can answer without loading the variation. Deliberately a
         // named set rather than a general projection: every addition here changes which selections switch to
@@ -450,10 +451,19 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
 
-            // An empty selection is not a subset to serve from the index - it is a caller asking for nothing -
-            // so the Count > 0 guard keeps it off this path.
+            // __typename is resolved from the schema and depends on no data, so a selection carrying it needs
+            // exactly what the same selection without it needs. Excluding it widens nothing: the spec reserves
+            // the __ prefix for introspection and graphql-dotnet rejects any other name that uses it when the
+            // schema is built, and of the three meta-fields only __typename is reachable on a nested field -
+            // __schema and __type exist on the root query type alone. Leaving it in would matter: clients that
+            // normalise a cache add __typename to every selection set, so the gate below would never fire.
+            var dataFields = includeFields.Where(x => x != TypeNameMetaField).ToList();
+
+            // Count is read off the raw selection, not the filtered one: a caller selecting nothing at all has
+            // asked for nothing and must not be served, while a caller selecting only __typename has asked for
+            // something the master's document can answer.
             if (includeFields.Count > 0 &&
-                includeFields.All(x => _masterAnswerableVariationFields.Contains(x, StringComparer.OrdinalIgnoreCase)))
+                dataFields.All(x => _masterAnswerableVariationFields.Contains(x, StringComparer.OrdinalIgnoreCase)))
             {
                 // The stored id list is already active-only: the indexer writes an id into the master's document
                 // only inside its IsActive branch, and any variation change forces a full reindex of the master.

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -280,13 +280,9 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                         return null;
                     }
 
-                    // No IsActive filter here: a master product is not a variation and is not subject to the
-                    // variations field's active-only contract.
-                    var loader = GetVariationLoader(context, context.SubFields.Values.GetAllNodesPaths(context).ToList());
-
-                    return loader
-                        .LoadAsync(context.Source.IndexedProduct.MainProductId)
-                        .Then(product => product is null ? null : new ExpVariation(product));
+                    // No IsActive filter here: a main product is not subject to the variations field's active-only contract.
+                    return LoadVariations(context, [context.Source.IndexedProduct.MainProductId], onlyActive: false)
+                        .Then(variations => variations.FirstOrDefault());
                 });
 
             ExtendableFieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<VariationType>>>>(
@@ -434,29 +430,19 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
         protected virtual Task<object> ResolveVariationsFieldAsync(IResolveFieldContext<ExpProduct> context)
         {
-            return Task.FromResult(ResolveVariationsField(context));
-        }
-
-        private object ResolveVariationsField(IResolveFieldContext<ExpProduct> context)
-        {
             if (context.Source.IndexedVariationIds.IsNullOrEmpty())
             {
-                return new List<ExpVariation>();
+                return Task.FromResult<object>(new List<ExpVariation>());
             }
 
-            var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
-
-            return GetVariationLoader(context, includeFields)
-                .LoadAsync(context.Source.IndexedVariationIds)
-                .Then(products => products
-                    .Where(x => x?.IndexedProduct?.IsActive == true)
-                    .Select(x => new ExpVariation(x))
-                    .ToList());
+            return Task.FromResult<object>(LoadVariations(context, context.Source.IndexedVariationIds, onlyActive: true));
         }
 
-        private IDataLoader<string, ExpProduct> GetVariationLoader(IResolveFieldContext context, List<string> includeFields)
+        private IDataLoaderResult<IEnumerable<ExpVariation>> LoadVariations(IResolveFieldContext context, IEnumerable<string> variationIds, bool onlyActive)
         {
-            // Requested for both fields, although only the variations field filters on it, so the two agree on a key.
+            var includeFields = context.SubFields.Values.GetAllNodesPaths(context).ToList();
+
+            // Always request isActive, so that filtered and unfiltered requests share the same key.
             if (!includeFields.Contains("isActive"))
             {
                 includeFields.Add("isActive");
@@ -464,7 +450,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
 
             var loaderKey = $"product_variations_{string.Join(',', includeFields.OrderBy(x => x, StringComparer.Ordinal))}";
 
-            return _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>(
+            var loader = _dataLoader.Context.GetOrAddBatchLoader<string, ExpProduct>(
                 loaderKey,
                 async ids =>
                 {
@@ -477,6 +463,12 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
                     return response.Products.ToDictionary(x => x.Id);
                 },
                 maxBatchSize: _maxVariationsBatchSize);
+
+            return loader
+                .LoadAsync(variationIds)
+                .Then(products => products
+                    .Where(x => x is not null && (!onlyActive || x.IndexedProduct?.IsActive == true))
+                    .Select(x => new ExpVariation(x)));
         }
 
         private static async Task<object> ResolveVideosConnectionAsync(IResolveConnectionContext<ExpProduct> context)

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
@@ -215,6 +215,66 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             results.Single().Select(x => x.Id).Should().Equal("active1");
         }
 
+        [Fact]
+        public async Task ResolveMasterVariationField_InactiveMainProduct_IsStillReturned()
+        {
+            _inactiveIds.Add("m1");
+
+            var variation = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "v1", MainProductId = "m1", IsActive = true },
+            };
+
+            var results = await ResolveMasterVariationNodesAsync((variation, _subFields));
+
+            results.Single().Id.Should().Be("m1");
+        }
+
+        [Fact]
+        public async Task ResolveMasterVariationField_MainProductIsNotFound_ReturnsNull()
+        {
+            _unresolvedIds.Add("m1");
+
+            var variation = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "v1", MainProductId = "m1", IsActive = true },
+            };
+
+            var results = await ResolveMasterVariationNodesAsync((variation, _subFields));
+
+            results.Single().Should().BeNull();
+            _sentFieldSets.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task ResolveVariationsField_NoVariationIds_SendsNoQuery()
+        {
+            var master = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
+                IndexedVariationIds = [],
+            };
+
+            var results = await ResolveVariationNodesAsync((master, _subFields));
+
+            results.Single().Should().BeEmpty();
+            _sentFieldSets.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task ResolveMasterVariationField_NoMainProductId_SendsNoQuery()
+        {
+            var product = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "p1", IsActive = true },
+            };
+
+            var results = await ResolveMasterVariationNodesAsync((product, _subFields));
+
+            results.Single().Should().BeNull();
+            _sentFieldSets.Should().BeEmpty();
+        }
+
         private Task<IList<IList<ExpVariation>>> ResolveVariationNodesAsync(params (ExpProduct Source, string[] SubFields)[] nodes)
         {
             return ResolveNodesAsync<IList<ExpVariation>>("variations", nodes);

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
@@ -104,7 +104,10 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 mediator, variations.Select(x => (x, new[] { "id", "name" })).ToArray());
 
             sentFieldSets.Should().HaveCount(1);
-            results.Should().HaveCount(3);
+
+            // Not a bare count: three nulls would satisfy that, and a .Then projection that resolved every
+            // master to null is exactly the failure a count cannot see.
+            results.Select(x => x.Id).Should().Equal("p1", "p2", "p3");
         }
 
         [Fact]
@@ -134,9 +137,10 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             var resolvedVariations = await CompleteNodeAsync(pendingVariations);
             var resolvedMasterVariation = await CompleteMasterVariationNodeAsync(pendingMasterVariation);
 
-            // The two fields build their loader key separately. Should those two compositions ever drift apart,
-            // each field registers its own loader and the page silently pays a second search - nothing else here
-            // would fail.
+            // What this pins is that masterVariation goes through the shared factory at all. Give it back its
+            // own LoadProductsQuery send - the shape it had before this branch, and the shape a reviewer might
+            // restore while "simplifying" the resolver - and the page pays a second search with every other
+            // assertion here still holding.
             sentFieldSets.Should().HaveCount(1);
             resolvedVariations.Should().ContainSingle();
             resolvedMasterVariation.Should().NotBeNull();

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
@@ -25,21 +25,25 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
     {
         private static readonly string[] _subFields = ["id", "name"];
 
+        private readonly HashSet<string> _inactiveIds = [];
+        private readonly HashSet<string> _unresolvedIds = [];
+
         private readonly ProductType _productType;
+        private readonly IMediator _mediator;
+
+        private readonly List<IList<string>> _sentFieldSets = [];
 
         public ProductTypeVariationsBatchingTests()
         {
             _dataLoaderContextAccessorMock.Setup(x => x.Context).Returns(new DataLoaderContext());
 
             _productType = new ProductType(_dataLoaderContextAccessorMock.Object);
+            _mediator = CreateRecordingMediator();
         }
 
         [Fact]
-        public async Task ResolveVariationsField_ThreeMastersOnOnePage_SendsOneLoadProductsQuery()
+        public async Task ResolveVariationsField_ThreeMastersOnOnePage_SendsOneQueryAndSplitsResultsByMaster()
         {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets);
-
             var masters = new[] { "m1", "m2", "m3" }
                 .Select((id, i) => new ExpProduct
                 {
@@ -48,29 +52,30 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 })
                 .ToList();
 
-            var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, _subFields)).ToArray());
+            var results = await ResolveVariationNodesAsync(masters.Select(x => (x, _subFields)).ToArray());
 
-            sentFieldSets.Should().HaveCount(1);
-            results.SelectMany(x => x).Should().HaveCount(6);
+            _sentFieldSets.Should().HaveCount(1);
+
+            for (var i = 0; i < masters.Count; i++)
+            {
+                results[i].Select(x => x.Id).Should().BeEquivalentTo(masters[i].IndexedVariationIds);
+            }
         }
 
         [Fact]
         public async Task ResolveVariationsField_TwoAliasesWithDifferentSubfields_DoNotShareALoader()
         {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets);
-
             var master = new ExpProduct
             {
                 IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
                 IndexedVariationIds = ["v1", "v2"],
             };
 
-            await ResolveVariationNodesAsync(mediator, (master, ["id", "name"]), (master, ["id", "code"]));
+            await ResolveVariationNodesAsync((master, ["id", "name"]), (master, ["id", "code"]));
 
-            sentFieldSets.Should().HaveCount(2);
+            _sentFieldSets.Should().HaveCount(2);
 
-            sentFieldSets
+            _sentFieldSets
                 .Select(x => string.Join(',', x.OrderBy(f => f, StringComparer.Ordinal)))
                 .Should().OnlyHaveUniqueItems();
         }
@@ -78,9 +83,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
         [Fact]
         public async Task ResolveMasterVariationField_ThreeVariationsOnOnePage_SendsOneLoadProductsQuery()
         {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets);
-
             var variations = new[] { "p1", "p2", "p3" }
                 .Select((id, i) => new ExpProduct
                 {
@@ -88,10 +90,9 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 })
                 .ToList();
 
-            var results = await ResolveMasterVariationNodesAsync(
-                mediator, variations.Select(x => (x, _subFields)).ToArray());
+            var results = await ResolveMasterVariationNodesAsync(variations.Select(x => (x, _subFields)).ToArray());
 
-            sentFieldSets.Should().HaveCount(1);
+            _sentFieldSets.Should().HaveCount(1);
 
             results.Select(x => x.Id).Should().Equal("p1", "p2", "p3");
         }
@@ -99,9 +100,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
         [Fact]
         public async Task ResolveVariationsAndMasterVariationFields_OnOnePage_SendOneLoadProductsQuery()
         {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets);
-
             var master = new ExpProduct
             {
                 IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
@@ -116,13 +114,13 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             var variationsField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("variations"));
             var masterVariationField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("masterVariation"));
 
-            var pendingVariations = await variationsField.Resolver.ResolveAsync(CreateResolveContext(master, mediator, _subFields));
-            var pendingMasterVariation = await masterVariationField.Resolver.ResolveAsync(CreateResolveContext(variation, mediator, _subFields));
+            var pendingVariations = await variationsField.Resolver.ResolveAsync(CreateResolveContext(master, _subFields));
+            var pendingMasterVariation = await masterVariationField.Resolver.ResolveAsync(CreateResolveContext(variation, _subFields));
 
-            var resolvedVariations = await CompleteNodeAsync(pendingVariations);
-            var resolvedMasterVariation = await CompleteMasterVariationNodeAsync(pendingMasterVariation);
+            var resolvedVariations = await CompleteNodeAsync<IList<ExpVariation>>(pendingVariations);
+            var resolvedMasterVariation = await CompleteNodeAsync<ExpVariation>(pendingMasterVariation);
 
-            sentFieldSets.Should().HaveCount(1);
+            _sentFieldSets.Should().HaveCount(1);
             resolvedVariations.Should().ContainSingle();
             resolvedMasterVariation.Should().NotBeNull();
         }
@@ -130,9 +128,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
         [Fact]
         public async Task ResolveVariationsField_SelectionIsIdOnly_SendsTheQuery()
         {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets);
-
             var master = new ExpProduct
             {
                 IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
@@ -142,18 +137,15 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             // Answering this from the master's own document is the tempting shortcut, and it drops the
             // startDate/endDate window that the search applies to every other selection - so an id-only
             // selection would return variations outside their validity window that "id name" filters out.
-            var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id" }));
+            var results = await ResolveVariationNodesAsync((master, ["id"]));
 
-            sentFieldSets.Should().HaveCount(1);
+            _sentFieldSets.Should().HaveCount(1);
             results.Single().Select(x => x.Id).Should().Equal("v1", "v2");
         }
 
         [Fact]
         public async Task ResolveVariationsField_IdsExceedTheBatchCap_SplitsIntoTwoLoadProductsQueries()
         {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets);
-
             var ids = Enumerable.Range(0, 201).Select(i => $"v{i}").ToList();
             var master = new ExpProduct
             {
@@ -161,18 +153,15 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ids,
             };
 
-            var results = await ResolveVariationNodesAsync(mediator, (master, _subFields));
+            var results = await ResolveVariationNodesAsync((master, _subFields));
 
-            sentFieldSets.Should().HaveCount(2);
+            _sentFieldSets.Should().HaveCount(2);
             results.Single().Should().HaveCount(201);
         }
 
         [Fact]
         public async Task ResolveVariationsField_IdSharedByTwoMasters_BothReceiveTheSameLoadedInstance()
         {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets);
-
             var masterA = new ExpProduct
             {
                 IndexedProduct = new CatalogProduct { Id = "ma", IsActive = true },
@@ -184,10 +173,9 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ["shared", "onlyB"],
             };
 
-            var results = await ResolveVariationNodesAsync(
-                mediator, (masterA, _subFields), (masterB, _subFields));
+            var results = await ResolveVariationNodesAsync((masterA, _subFields), (masterB, _subFields));
 
-            sentFieldSets.Should().HaveCount(1);
+            _sentFieldSets.Should().HaveCount(1);
 
             var sharedFromA = results[0].Single(x => x.Id == "shared");
             var sharedFromB = results[1].Single(x => x.Id == "shared");
@@ -198,8 +186,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
         [Fact]
         public async Task ResolveVariationsField_AnIdTheLoadDoesNotResolve_IsAbsentFromTheResult()
         {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets, unresolvedIds: new HashSet<string> { "gone" });
+            _unresolvedIds.Add("gone");
 
             var master = new ExpProduct
             {
@@ -207,7 +194,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ["v1", "gone"],
             };
 
-            var results = await ResolveVariationNodesAsync(mediator, (master, _subFields));
+            var results = await ResolveVariationNodesAsync((master, _subFields));
 
             results.Single().Select(x => x.Id).Should().Equal("v1");
         }
@@ -215,8 +202,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
         [Fact]
         public async Task ResolveVariationsField_MixOfActiveAndInactiveVariations_ExcludesInactiveOnes()
         {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets, isActive: id => id != "inactive");
+            _inactiveIds.Add("inactive");
 
             var master = new ExpProduct
             {
@@ -224,99 +210,53 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ["active1", "inactive"],
             };
 
-            var results = await ResolveVariationNodesAsync(mediator, (master, _subFields));
+            var results = await ResolveVariationNodesAsync((master, _subFields));
 
             results.Single().Select(x => x.Id).Should().Equal("active1");
         }
 
-        [Fact]
-        public async Task ResolveVariationsField_ThreeMastersOnOnePage_EachReceivesExactlyItsOwnVariationIds()
+        private Task<IList<IList<ExpVariation>>> ResolveVariationNodesAsync(params (ExpProduct Source, string[] SubFields)[] nodes)
         {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets);
-
-            var masters = new[] { "m1", "m2", "m3" }
-                .Select((id, i) => new ExpProduct
-                {
-                    IndexedProduct = new CatalogProduct { Id = id, IsActive = true },
-                    IndexedVariationIds = [$"v{i}a", $"v{i}b"],
-                })
-                .ToList();
-
-            var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, _subFields)).ToArray());
-
-            for (var i = 0; i < masters.Count; i++)
-            {
-                results[i].Select(x => x.Id).Should().BeEquivalentTo(masters[i].IndexedVariationIds);
-            }
+            return ResolveNodesAsync<IList<ExpVariation>>("variations", nodes);
         }
 
-        private async Task<IList<IList<ExpVariation>>> ResolveVariationNodesAsync(
-            IMediator mediator,
-            params (ExpProduct Master, string[] SubFields)[] nodes)
+        private Task<IList<ExpVariation>> ResolveMasterVariationNodesAsync(params (ExpProduct Source, string[] SubFields)[] nodes)
         {
-            var variationsField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("variations"));
+            return ResolveNodesAsync<ExpVariation>("masterVariation", nodes);
+        }
+
+        private async Task<IList<T>> ResolveNodesAsync<T>(string fieldName, (ExpProduct Source, string[] SubFields)[] nodes)
+        {
+            var field = _productType.Fields.First(x => x.Name.EqualsIgnoreCase(fieldName));
 
             // Every node is resolved before any is completed. Completing one at a time dispatches a batch of one
             // each time and reports one send per node against a correctly batched resolver.
             var pending = new List<object>();
-            foreach (var (master, subFields) in nodes)
+            foreach (var (source, subFields) in nodes)
             {
-                pending.Add(await variationsField.Resolver.ResolveAsync(CreateResolveContext(master, mediator, subFields)));
+                pending.Add(await field.Resolver.ResolveAsync(CreateResolveContext(source, subFields)));
             }
 
-            var results = new List<IList<ExpVariation>>();
+            var results = new List<T>();
             foreach (var item in pending)
             {
-                results.Add(await CompleteNodeAsync(item));
+                results.Add(await CompleteNodeAsync<T>(item));
             }
 
             return results;
         }
 
-        private async Task<IList<ExpVariation>> ResolveMasterVariationNodesAsync(
-            IMediator mediator,
-            params (ExpProduct Variation, string[] SubFields)[] nodes)
+        private static async Task<T> CompleteNodeAsync<T>(object resolved)
         {
-            var masterVariationField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("masterVariation"));
+            resolved.Should().BeAssignableTo<IDataLoaderResult<T>>();
 
-            var pending = new List<object>();
-            foreach (var (variation, subFields) in nodes)
-            {
-                pending.Add(await masterVariationField.Resolver.ResolveAsync(CreateResolveContext(variation, mediator, subFields)));
-            }
-
-            var results = new List<ExpVariation>();
-            foreach (var item in pending)
-            {
-                results.Add(await CompleteMasterVariationNodeAsync(item));
-            }
-
-            return results;
+            return await ((IDataLoaderResult<T>)resolved).GetResultAsync();
         }
 
-        private static async Task<IList<ExpVariation>> CompleteNodeAsync(object resolved)
-        {
-            var value = resolved is IDataLoaderResult loaderResult
-                ? await loaderResult.GetResultAsync()
-                : resolved;
-
-            return ((IEnumerable<ExpVariation>)value).ToList();
-        }
-
-        private static async Task<ExpVariation> CompleteMasterVariationNodeAsync(object resolved)
-        {
-            var value = resolved is IDataLoaderResult loaderResult
-                ? await loaderResult.GetResultAsync()
-                : resolved;
-
-            return (ExpVariation)value;
-        }
-
-        private static ResolveFieldContext CreateResolveContext(ExpProduct source, IMediator mediator, string[] subFields)
+        private ResolveFieldContext CreateResolveContext(ExpProduct source, string[] subFields)
         {
             var serviceProviderMock = new Mock<IServiceProvider>();
-            serviceProviderMock.Setup(x => x.GetService(typeof(IMediator))).Returns(mediator);
+            serviceProviderMock.Setup(x => x.GetService(typeof(IMediator))).Returns(_mediator);
 
             return new ResolveFieldContext
             {
@@ -329,7 +269,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             };
         }
 
-        private static IMediator CreateRecordingMediator(List<IList<string>> sentFieldSets)
+        private IMediator CreateRecordingMediator()
         {
             var mediatorMock = new Mock<IMediator>();
 
@@ -337,51 +277,14 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 .Setup(x => x.Send(It.IsAny<LoadProductsQuery>(), It.IsAny<CancellationToken>()))
                 .Returns((LoadProductsQuery query, CancellationToken _) =>
                 {
-                    sentFieldSets.Add(query.IncludeFields.ToList());
+                    _sentFieldSets.Add(query.IncludeFields.ToList());
 
                     var products = query.ObjectIds
-                        .Select(id => new ExpProduct { IndexedProduct = new CatalogProduct { Id = id, IsActive = true } })
-                        .ToList();
-
-                    return Task.FromResult(new LoadProductResponse(products));
-                });
-
-            return mediatorMock.Object;
-        }
-
-        private static IMediator CreateRecordingMediator(List<IList<string>> sentFieldSets, Func<string, bool> isActive)
-        {
-            var mediatorMock = new Mock<IMediator>();
-
-            mediatorMock
-                .Setup(x => x.Send(It.IsAny<LoadProductsQuery>(), It.IsAny<CancellationToken>()))
-                .Returns((LoadProductsQuery query, CancellationToken _) =>
-                {
-                    sentFieldSets.Add(query.IncludeFields.ToList());
-
-                    var products = query.ObjectIds
-                        .Select(id => new ExpProduct { IndexedProduct = new CatalogProduct { Id = id, IsActive = isActive(id) } })
-                        .ToList();
-
-                    return Task.FromResult(new LoadProductResponse(products));
-                });
-
-            return mediatorMock.Object;
-        }
-
-        private static IMediator CreateRecordingMediator(List<IList<string>> sentFieldSets, HashSet<string> unresolvedIds)
-        {
-            var mediatorMock = new Mock<IMediator>();
-
-            mediatorMock
-                .Setup(x => x.Send(It.IsAny<LoadProductsQuery>(), It.IsAny<CancellationToken>()))
-                .Returns((LoadProductsQuery query, CancellationToken _) =>
-                {
-                    sentFieldSets.Add(query.IncludeFields.ToList());
-
-                    var products = query.ObjectIds
-                        .Where(id => !unresolvedIds.Contains(id))
-                        .Select(id => new ExpProduct { IndexedProduct = new CatalogProduct { Id = id, IsActive = true } })
+                        .Where(id => !_unresolvedIds.Contains(id))
+                        .Select(id => new ExpProduct
+                        {
+                            IndexedProduct = new CatalogProduct { Id = id, IsActive = !_inactiveIds.Contains(id) },
+                        })
                         .ToList();
 
                     return Task.FromResult(new LoadProductResponse(products));

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
@@ -184,6 +184,46 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
         }
 
         [Fact]
+        public async Task ResolveVariationsField_SelectionIsIdAndTypeName_SendsNoLoadProductsQuery()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets);
+
+            var master = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
+                IndexedVariationIds = ["v1", "v2"],
+            };
+
+            // This, not the bare id-only case, is what an id-only source query looks like on the wire: a client
+            // that normalises a cache adds __typename to every selection set. A gate that treats it as a data
+            // field is a gate that never fires in production while passing every test written without it.
+            var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "__typename" }));
+
+            sentFieldSets.Should().BeEmpty();
+            results.Single().Select(x => x.Id).Should().Equal("v1", "v2");
+        }
+
+        [Fact]
+        public async Task ResolveVariationsField_SelectionIsTypeNameBesideALoadedField_StillSendsTheQuery()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets);
+
+            var master = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
+                IndexedVariationIds = ["v1", "v2"],
+            };
+
+            // Discounting __typename must not discount anything else: a selection that still needs a loaded
+            // field takes the loaded path.
+            await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name", "__typename" }));
+
+            sentFieldSets.Should().HaveCount(1);
+        }
+
+        [Fact]
         public async Task ResolveVariationsField_IdsExceedTheBatchCap_SplitsIntoTwoLoadProductsQueries()
         {
             var sentFieldSets = new List<IList<string>>();

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
@@ -28,6 +28,17 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
     /// </summary>
     public class ProductTypeVariationsBatchingTests : XCatalogMoqHelper
     {
+        private readonly ProductType _productType;
+
+        public ProductTypeVariationsBatchingTests()
+        {
+            // A mock IDataLoaderContextAccessor returns a null Context, and the loader would never be reached.
+            // One context per test, shared by every node, is what a single request gives the resolvers.
+            _dataLoaderContextAccessorMock.Setup(x => x.Context).Returns(new DataLoaderContext());
+
+            _productType = new ProductType(_dataLoaderContextAccessorMock.Object);
+        }
+
         [Fact]
         public async Task ResolveVariationsField_ThreeMastersOnOnePage_SendsOneLoadProductsQuery()
         {
@@ -76,6 +87,61 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 .Should().OnlyHaveUniqueItems();
         }
 
+        [Fact]
+        public async Task ResolveMasterVariationField_ThreeVariationsOnOnePage_SendsOneLoadProductsQuery()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets);
+
+            var variations = new[] { "p1", "p2", "p3" }
+                .Select((id, i) => new ExpProduct
+                {
+                    IndexedProduct = new CatalogProduct { Id = $"v{i}", MainProductId = id, IsActive = true },
+                })
+                .ToList();
+
+            var results = await ResolveMasterVariationNodesAsync(
+                mediator, variations.Select(x => (x, new[] { "id", "name" })).ToArray());
+
+            sentFieldSets.Should().HaveCount(1);
+            results.Should().HaveCount(3);
+        }
+
+        [Fact]
+        public async Task ResolveVariationsAndMasterVariationFields_OnOnePage_SendOneLoadProductsQuery()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets);
+
+            var master = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
+                IndexedVariationIds = ["v1"],
+            };
+
+            var variation = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "v9", MainProductId = "m2", IsActive = true },
+            };
+
+            var variationsField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("variations"));
+            var masterVariationField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("masterVariation"));
+
+            // Both nodes resolved and queued before either is completed, as in the single-field helpers.
+            var pendingVariations = await variationsField.Resolver.ResolveAsync(CreateResolveContext(master, mediator, ["id", "name"]));
+            var pendingMasterVariation = await masterVariationField.Resolver.ResolveAsync(CreateResolveContext(variation, mediator, ["id", "name"]));
+
+            var resolvedVariations = await CompleteNodeAsync(pendingVariations);
+            var resolvedMasterVariation = await CompleteMasterVariationNodeAsync(pendingMasterVariation);
+
+            // The two fields build their loader key separately. Should those two compositions ever drift apart,
+            // each field registers its own loader and the page silently pays a second search - nothing else here
+            // would fail.
+            sentFieldSets.Should().HaveCount(1);
+            resolvedVariations.Should().ContainSingle();
+            resolvedMasterVariation.Should().NotBeNull();
+        }
+
         /// <summary>
         /// Drives the registered <c>variations</c> field over several sibling nodes sharing one
         /// <see cref="DataLoaderContext"/>, the way one request does.
@@ -84,11 +150,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             IMediator mediator,
             params (ExpProduct Master, string[] SubFields)[] nodes)
         {
-            // A mock IDataLoaderContextAccessor returns a null Context, and the loader would never be reached.
-            _dataLoaderContextAccessorMock.Setup(x => x.Context).Returns(new DataLoaderContext());
-
-            var productType = new ProductType(_dataLoaderContextAccessorMock.Object);
-            var variationsField = productType.Fields.First(x => x.Name.EqualsIgnoreCase("variations"));
+            var variationsField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("variations"));
 
             // Every node must be resolved - and its loader result queued - before the first one is completed.
             // This mirrors the execution strategy, which runs ExecuteNodeAsync across sibling nodes and only
@@ -111,6 +173,33 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
         }
 
         /// <summary>
+        /// Drives the registered <c>masterVariation</c> field over several sibling nodes sharing one
+        /// <see cref="DataLoaderContext"/> - the single-result counterpart of <see cref="ResolveVariationNodesAsync"/>.
+        /// </summary>
+        private async Task<IList<ExpVariation>> ResolveMasterVariationNodesAsync(
+            IMediator mediator,
+            params (ExpProduct Variation, string[] SubFields)[] nodes)
+        {
+            var masterVariationField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("masterVariation"));
+
+            // Same ordering requirement as ResolveVariationNodesAsync: every node resolved and queued before
+            // the first one is completed.
+            var pending = new List<object>();
+            foreach (var (variation, subFields) in nodes)
+            {
+                pending.Add(await masterVariationField.Resolver.ResolveAsync(CreateResolveContext(variation, mediator, subFields)));
+            }
+
+            var results = new List<ExpVariation>();
+            foreach (var item in pending)
+            {
+                results.Add(await CompleteMasterVariationNodeAsync(item));
+            }
+
+            return results;
+        }
+
+        /// <summary>
         /// Completes one resolved node the way the execution strategy does - by the resolved value's runtime
         /// type. A resolver that loaded eagerly hands back the finished sequence instead of a pending result.
         /// </summary>
@@ -121,6 +210,19 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 : resolved;
 
             return ((IEnumerable<ExpVariation>)value).ToList();
+        }
+
+        /// <summary>
+        /// <see cref="CompleteNodeAsync"/> for <c>masterVariation</c>, whose resolved value is a single
+        /// <see cref="ExpVariation"/> rather than a list.
+        /// </summary>
+        private static async Task<ExpVariation> CompleteMasterVariationNodeAsync(object resolved)
+        {
+            var value = resolved is IDataLoaderResult loaderResult
+                ? await loaderResult.GetResultAsync()
+                : resolved;
+
+            return (ExpVariation)value;
         }
 
         private static IResolveFieldContext CreateResolveContext(ExpProduct source, IMediator mediator, string[] subFields)

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
@@ -21,19 +21,12 @@ using Xunit;
 
 namespace VirtoCommerce.XCatalog.Tests.Schemas
 {
-    /// <summary>
-    /// The subject is the number of <see cref="LoadProductsQuery"/> sends a page of masters produces, not the
-    /// variations that come back: the returned variations are correct both before and after batching, so only
-    /// the send count scales with the bug.
-    /// </summary>
     public class ProductTypeVariationsBatchingTests : XCatalogMoqHelper
     {
         private readonly ProductType _productType;
 
         public ProductTypeVariationsBatchingTests()
         {
-            // A mock IDataLoaderContextAccessor returns a null Context, and the loader would never be reached.
-            // One context per test, shared by every node, is what a single request gives the resolvers.
             _dataLoaderContextAccessorMock.Setup(x => x.Context).Returns(new DataLoaderContext());
 
             _productType = new ProductType(_dataLoaderContextAccessorMock.Object);
@@ -53,8 +46,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 })
                 .ToList();
 
-            // "name" alongside "id" keeps the selection deliberately not id-only, so this exercises batching
-            // rather than any selection that can be answered from the master's own document.
             var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, new[] { "id", "name" })).ToArray());
 
             sentFieldSets.Should().HaveCount(1);
@@ -73,15 +64,10 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ["v1", "v2"],
             };
 
-            // Neither alias is id-only: a later gate short-circuits an id-only selection before the loader is
-            // reached, which would make this test fail for a reason that is not the key.
             await ResolveVariationNodesAsync(mediator, (master, ["id", "name"]), (master, ["id", "code"]));
 
             sentFieldSets.Should().HaveCount(2);
 
-            // Compare the CONTENT of the two field sets, not the two list objects: OnlyHaveUniqueItems over
-            // IList<string> compares references, which differ by construction, so it would pass against a
-            // loader key that ignores the field set entirely.
             sentFieldSets
                 .Select(x => string.Join(',', x.OrderBy(f => f, StringComparer.Ordinal)))
                 .Should().OnlyHaveUniqueItems();
@@ -105,8 +91,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
 
             sentFieldSets.Should().HaveCount(1);
 
-            // Not a bare count: three nulls would satisfy that, and a .Then projection that resolved every
-            // master to null is exactly the failure a count cannot see.
             results.Select(x => x.Id).Should().Equal("p1", "p2", "p3");
         }
 
@@ -130,17 +114,12 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             var variationsField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("variations"));
             var masterVariationField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("masterVariation"));
 
-            // Both nodes resolved and queued before either is completed, as in the single-field helpers.
             var pendingVariations = await variationsField.Resolver.ResolveAsync(CreateResolveContext(master, mediator, ["id", "name"]));
             var pendingMasterVariation = await masterVariationField.Resolver.ResolveAsync(CreateResolveContext(variation, mediator, ["id", "name"]));
 
             var resolvedVariations = await CompleteNodeAsync(pendingVariations);
             var resolvedMasterVariation = await CompleteMasterVariationNodeAsync(pendingMasterVariation);
 
-            // What this pins is that masterVariation goes through the shared factory at all. Give it back its
-            // own LoadProductsQuery send - the shape it had before this branch, and the shape a reviewer might
-            // restore while "simplifying" the resolver - and the page pays a second search with every other
-            // assertion here still holding.
             sentFieldSets.Should().HaveCount(1);
             resolvedVariations.Should().ContainSingle();
             resolvedMasterVariation.Should().NotBeNull();
@@ -176,8 +155,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ["v1", "v2"],
             };
 
-            // The positive control: without it, the id-only test above would pass against a resolver that
-            // never loads anything at all, regardless of whether the gate is subset-correct.
             await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name" }));
 
             sentFieldSets.Should().HaveCount(1);
@@ -196,8 +173,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             };
 
             // This, not the bare id-only case, is what an id-only source query looks like on the wire: a client
-            // that normalises a cache adds __typename to every selection set. A gate that treats it as a data
-            // field is a gate that never fires in production while passing every test written without it.
+            // that normalises a cache adds __typename to every selection set.
             var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "__typename" }));
 
             sentFieldSets.Should().BeEmpty();
@@ -216,8 +192,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ["v1", "v2"],
             };
 
-            // Discounting __typename must not discount anything else: a selection that still needs a loaded
-            // field takes the loaded path.
             await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name", "__typename" }));
 
             sentFieldSets.Should().HaveCount(1);
@@ -229,8 +203,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             var sentFieldSets = new List<IList<string>>();
             var mediator = CreateRecordingMediator(sentFieldSets);
 
-            // One more id than the loader's maxBatchSize, so the split is observable rather than assumed:
-            // a single fetch would silently absorb any id count up to the cap.
             var ids = Enumerable.Range(0, 201).Select(i => $"v{i}").ToList();
             var master = new ExpProduct
             {
@@ -269,10 +241,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             var sharedFromA = results[0].Single(x => x.Id == "shared");
             var sharedFromB = results[1].Single(x => x.Id == "shared");
 
-            // ExpVariation forwards the source ExpProduct's IndexedProduct reference rather than cloning it
-            // (see ExpVariation's constructor), so identical IndexedProduct references across both masters'
-            // results is the loader's per-key cache actually sharing one fetched instance - not two
-            // independently-built copies that merely compare equal by value.
             sharedFromA.IndexedProduct.Should().BeSameAs(sharedFromB.IndexedProduct);
         }
 
@@ -290,9 +258,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
 
             var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name" }));
 
-            // Not "contains v1" - the unresolved id must be absent, not present as a null/placeholder element.
-            // The field's graph type is NonNullGraphType<ListGraphType<NonNullGraphType<VariationType>>>, so a
-            // null element reaching graphql-dotnet would be a runtime execution error, not a quiet gap.
             results.Single().Select(x => x.Id).Should().Equal("v1");
         }
 
@@ -310,8 +275,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
 
             var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name" }));
 
-            // Every other test's mediator returns IsActive = true for everything, so this is the only test
-            // that exercises the Where(x => x?.IndexedProduct?.IsActive == true) filter as an actual filter.
             results.Single().Select(x => x.Id).Should().Equal("active1");
         }
 
@@ -331,29 +294,20 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
 
             var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, new[] { "id", "name" })).ToArray());
 
-            // The page test above only asserts the total (6), which a loader bug that handed every master all
-            // six ids would also satisfy. This checks each master's result against exactly its own ids.
             for (var i = 0; i < masters.Count; i++)
             {
                 results[i].Select(x => x.Id).Should().BeEquivalentTo(masters[i].IndexedVariationIds);
             }
         }
 
-        /// <summary>
-        /// Drives the registered <c>variations</c> field over several sibling nodes sharing one
-        /// <see cref="DataLoaderContext"/>, the way one request does.
-        /// </summary>
         private async Task<IList<IList<ExpVariation>>> ResolveVariationNodesAsync(
             IMediator mediator,
             params (ExpProduct Master, string[] SubFields)[] nodes)
         {
             var variationsField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("variations"));
 
-            // Every node must be resolved - and its loader result queued - before the first one is completed.
-            // This mirrors the execution strategy, which runs ExecuteNodeAsync across sibling nodes and only
-            // then completes the pending data-loader nodes. Resolving and completing one node at a time
-            // dispatches a batch of one each time and reports one send per node against a correctly batched
-            // implementation - a failure that is not the bug.
+            // Every node is resolved before any is completed. Completing one at a time dispatches a batch of one
+            // each time and reports one send per node against a correctly batched resolver.
             var pending = new List<object>();
             foreach (var (master, subFields) in nodes)
             {
@@ -369,18 +323,12 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             return results;
         }
 
-        /// <summary>
-        /// Drives the registered <c>masterVariation</c> field over several sibling nodes sharing one
-        /// <see cref="DataLoaderContext"/> - the single-result counterpart of <see cref="ResolveVariationNodesAsync"/>.
-        /// </summary>
         private async Task<IList<ExpVariation>> ResolveMasterVariationNodesAsync(
             IMediator mediator,
             params (ExpProduct Variation, string[] SubFields)[] nodes)
         {
             var masterVariationField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("masterVariation"));
 
-            // Same ordering requirement as ResolveVariationNodesAsync: every node resolved and queued before
-            // the first one is completed.
             var pending = new List<object>();
             foreach (var (variation, subFields) in nodes)
             {
@@ -396,10 +344,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             return results;
         }
 
-        /// <summary>
-        /// Completes one resolved node the way the execution strategy does - by the resolved value's runtime
-        /// type. A resolver that loaded eagerly hands back the finished sequence instead of a pending result.
-        /// </summary>
         private static async Task<IList<ExpVariation>> CompleteNodeAsync(object resolved)
         {
             var value = resolved is IDataLoaderResult loaderResult
@@ -409,10 +353,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             return ((IEnumerable<ExpVariation>)value).ToList();
         }
 
-        /// <summary>
-        /// <see cref="CompleteNodeAsync"/> for <c>masterVariation</c>, whose resolved value is a single
-        /// <see cref="ExpVariation"/> rather than a list.
-        /// </summary>
         private static async Task<ExpVariation> CompleteMasterVariationNodeAsync(object resolved)
         {
             var value = resolved is IDataLoaderResult loaderResult
@@ -430,10 +370,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             return new ResolveFieldContext
             {
                 Source = source,
-                // GetCatalogQuery reaches the current principal through a GraphQLUserContext cast, which a plain
-                // dictionary fails.
                 UserContext = new GraphQLUserContext(null) { { "cultureName", CULTURE_NAME } },
-                // The resolver reaches the mediator through context.GetMediator(), which requires RequestServices.
                 RequestServices = serviceProviderMock.Object,
                 SubFields = subFields.ToDictionary(
                     x => x,
@@ -461,10 +398,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             return mediatorMock.Object;
         }
 
-        /// <summary>
-        /// <see cref="CreateRecordingMediator(IList{IList{string}})"/> with the resolved products' IsActive
-        /// flag driven per id, for tests that need a mix rather than every product uniformly active.
-        /// </summary>
         private static IMediator CreateRecordingMediator(IList<IList<string>> sentFieldSets, Func<string, bool> isActive)
         {
             var mediatorMock = new Mock<IMediator>();
@@ -485,11 +418,6 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             return mediatorMock.Object;
         }
 
-        /// <summary>
-        /// <see cref="CreateRecordingMediator(IList{IList{string}})"/> with the given ids dropped from the
-        /// response, simulating the fetch func's documented partial-dictionary contract: an id the load does
-        /// not resolve is simply missing, not present with a null/placeholder value.
-        /// </summary>
         private static IMediator CreateRecordingMediator(IList<IList<string>> sentFieldSets, ISet<string> unresolvedIds)
         {
             var mediatorMock = new Mock<IMediator>();

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
@@ -179,6 +179,122 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             sentFieldSets.Should().HaveCount(1);
         }
 
+        [Fact]
+        public async Task ResolveVariationsField_IdsExceedTheBatchCap_SplitsIntoTwoLoadProductsQueries()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets);
+
+            // One more id than the loader's maxBatchSize, so the split is observable rather than assumed:
+            // a single fetch would silently absorb any id count up to the cap.
+            var ids = Enumerable.Range(0, 201).Select(i => $"v{i}").ToList();
+            var master = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
+                IndexedVariationIds = ids,
+            };
+
+            var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name" }));
+
+            sentFieldSets.Should().HaveCount(2);
+            results.Single().Should().HaveCount(201);
+        }
+
+        [Fact]
+        public async Task ResolveVariationsField_IdSharedByTwoMasters_BothReceiveTheSameLoadedInstance()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets);
+
+            var masterA = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "ma", IsActive = true },
+                IndexedVariationIds = ["shared", "onlyA"],
+            };
+            var masterB = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "mb", IsActive = true },
+                IndexedVariationIds = ["shared", "onlyB"],
+            };
+
+            var results = await ResolveVariationNodesAsync(
+                mediator, (masterA, new[] { "id", "name" }), (masterB, new[] { "id", "name" }));
+
+            sentFieldSets.Should().HaveCount(1);
+
+            var sharedFromA = results[0].Single(x => x.Id == "shared");
+            var sharedFromB = results[1].Single(x => x.Id == "shared");
+
+            // ExpVariation forwards the source ExpProduct's IndexedProduct reference rather than cloning it
+            // (see ExpVariation's constructor), so identical IndexedProduct references across both masters'
+            // results is the loader's per-key cache actually sharing one fetched instance - not two
+            // independently-built copies that merely compare equal by value.
+            sharedFromA.IndexedProduct.Should().BeSameAs(sharedFromB.IndexedProduct);
+        }
+
+        [Fact]
+        public async Task ResolveVariationsField_AnIdTheLoadDoesNotResolve_IsAbsentFromTheResult()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets, unresolvedIds: new HashSet<string> { "gone" });
+
+            var master = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
+                IndexedVariationIds = ["v1", "gone"],
+            };
+
+            var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name" }));
+
+            // Not "contains v1" - the unresolved id must be absent, not present as a null/placeholder element.
+            // The field's graph type is NonNullGraphType<ListGraphType<NonNullGraphType<VariationType>>>, so a
+            // null element reaching graphql-dotnet would be a runtime execution error, not a quiet gap.
+            results.Single().Select(x => x.Id).Should().Equal("v1");
+        }
+
+        [Fact]
+        public async Task ResolveVariationsField_MixOfActiveAndInactiveVariations_ExcludesInactiveOnes()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets, isActive: id => id != "inactive");
+
+            var master = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
+                IndexedVariationIds = ["active1", "inactive"],
+            };
+
+            var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name" }));
+
+            // Every other test's mediator returns IsActive = true for everything, so this is the only test
+            // that exercises the Where(x => x?.IndexedProduct?.IsActive == true) filter as an actual filter.
+            results.Single().Select(x => x.Id).Should().Equal("active1");
+        }
+
+        [Fact]
+        public async Task ResolveVariationsField_ThreeMastersOnOnePage_EachReceivesExactlyItsOwnVariationIds()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets);
+
+            var masters = new[] { "m1", "m2", "m3" }
+                .Select((id, i) => new ExpProduct
+                {
+                    IndexedProduct = new CatalogProduct { Id = id, IsActive = true },
+                    IndexedVariationIds = [$"v{i}a", $"v{i}b"],
+                })
+                .ToList();
+
+            var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, new[] { "id", "name" })).ToArray());
+
+            // The page test above only asserts the total (6), which a loader bug that handed every master all
+            // six ids would also satisfy. This checks each master's result against exactly its own ids.
+            for (var i = 0; i < masters.Count; i++)
+            {
+                results[i].Select(x => x.Id).Should().BeEquivalentTo(masters[i].IndexedVariationIds);
+            }
+        }
+
         /// <summary>
         /// Drives the registered <c>variations</c> field over several sibling nodes sharing one
         /// <see cref="DataLoaderContext"/>, the way one request does.
@@ -292,6 +408,56 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                     sentFieldSets.Add(query.IncludeFields.ToList());
 
                     var products = query.ObjectIds
+                        .Select(id => new ExpProduct { IndexedProduct = new CatalogProduct { Id = id, IsActive = true } })
+                        .ToList();
+
+                    return Task.FromResult(new LoadProductResponse(products));
+                });
+
+            return mediatorMock.Object;
+        }
+
+        /// <summary>
+        /// <see cref="CreateRecordingMediator(IList{IList{string}})"/> with the resolved products' IsActive
+        /// flag driven per id, for tests that need a mix rather than every product uniformly active.
+        /// </summary>
+        private static IMediator CreateRecordingMediator(IList<IList<string>> sentFieldSets, Func<string, bool> isActive)
+        {
+            var mediatorMock = new Mock<IMediator>();
+
+            mediatorMock
+                .Setup(x => x.Send(It.IsAny<LoadProductsQuery>(), It.IsAny<CancellationToken>()))
+                .Returns((LoadProductsQuery query, CancellationToken _) =>
+                {
+                    sentFieldSets.Add(query.IncludeFields.ToList());
+
+                    var products = query.ObjectIds
+                        .Select(id => new ExpProduct { IndexedProduct = new CatalogProduct { Id = id, IsActive = isActive(id) } })
+                        .ToList();
+
+                    return Task.FromResult(new LoadProductResponse(products));
+                });
+
+            return mediatorMock.Object;
+        }
+
+        /// <summary>
+        /// <see cref="CreateRecordingMediator(IList{IList{string}})"/> with the given ids dropped from the
+        /// response, simulating the fetch func's documented partial-dictionary contract: an id the load does
+        /// not resolve is simply missing, not present with a null/placeholder value.
+        /// </summary>
+        private static IMediator CreateRecordingMediator(IList<IList<string>> sentFieldSets, ISet<string> unresolvedIds)
+        {
+            var mediatorMock = new Mock<IMediator>();
+
+            mediatorMock
+                .Setup(x => x.Send(It.IsAny<LoadProductsQuery>(), It.IsAny<CancellationToken>()))
+                .Returns((LoadProductsQuery query, CancellationToken _) =>
+                {
+                    sentFieldSets.Add(query.IncludeFields.ToList());
+
+                    var products = query.ObjectIds
+                        .Where(id => !unresolvedIds.Contains(id))
                         .Select(id => new ExpProduct { IndexedProduct = new CatalogProduct { Id = id, IsActive = true } })
                         .ToList();
 

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
@@ -142,6 +142,43 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             resolvedMasterVariation.Should().NotBeNull();
         }
 
+        [Fact]
+        public async Task ResolveVariationsField_SelectionIsIdOnly_SendsNoLoadProductsQuery()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets);
+
+            var master = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
+                IndexedVariationIds = ["v1", "v2"],
+            };
+
+            var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id" }));
+
+            sentFieldSets.Should().BeEmpty();
+            results.Single().Select(x => x.Id).Should().Equal("v1", "v2");
+        }
+
+        [Fact]
+        public async Task ResolveVariationsField_SelectionNeedsALoadedField_StillSendsTheQuery()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets);
+
+            var master = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
+                IndexedVariationIds = ["v1", "v2"],
+            };
+
+            // The positive control: without it, the id-only test above would pass against a resolver that
+            // never loads anything at all, regardless of whether the gate is subset-correct.
+            await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name" }));
+
+            sentFieldSets.Should().HaveCount(1);
+        }
+
         /// <summary>
         /// Drives the registered <c>variations</c> field over several sibling nodes sharing one
         /// <see cref="DataLoaderContext"/>, the way one request does.

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
@@ -23,6 +23,10 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
 {
     public class ProductTypeVariationsBatchingTests : XCatalogMoqHelper
     {
+        // "name" is not one of the fields the master's document answers, so this selection is the one that
+        // reaches the loader. Tests about batching use it; tests about the gate spell their selection out.
+        private static readonly string[] _selectionRequiringLoad = ["id", "name"];
+
         private readonly ProductType _productType;
 
         public ProductTypeVariationsBatchingTests()
@@ -46,7 +50,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 })
                 .ToList();
 
-            var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, new[] { "id", "name" })).ToArray());
+            var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, _selectionRequiringLoad)).ToArray());
 
             sentFieldSets.Should().HaveCount(1);
             results.SelectMany(x => x).Should().HaveCount(6);
@@ -87,7 +91,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 .ToList();
 
             var results = await ResolveMasterVariationNodesAsync(
-                mediator, variations.Select(x => (x, new[] { "id", "name" })).ToArray());
+                mediator, variations.Select(x => (x, _selectionRequiringLoad)).ToArray());
 
             sentFieldSets.Should().HaveCount(1);
 
@@ -114,8 +118,8 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             var variationsField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("variations"));
             var masterVariationField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("masterVariation"));
 
-            var pendingVariations = await variationsField.Resolver.ResolveAsync(CreateResolveContext(master, mediator, ["id", "name"]));
-            var pendingMasterVariation = await masterVariationField.Resolver.ResolveAsync(CreateResolveContext(variation, mediator, ["id", "name"]));
+            var pendingVariations = await variationsField.Resolver.ResolveAsync(CreateResolveContext(master, mediator, _selectionRequiringLoad));
+            var pendingMasterVariation = await masterVariationField.Resolver.ResolveAsync(CreateResolveContext(variation, mediator, _selectionRequiringLoad));
 
             var resolvedVariations = await CompleteNodeAsync(pendingVariations);
             var resolvedMasterVariation = await CompleteMasterVariationNodeAsync(pendingMasterVariation);
@@ -155,7 +159,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ["v1", "v2"],
             };
 
-            await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name" }));
+            await ResolveVariationNodesAsync(mediator, (master, _selectionRequiringLoad));
 
             sentFieldSets.Should().HaveCount(1);
         }
@@ -210,7 +214,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ids,
             };
 
-            var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name" }));
+            var results = await ResolveVariationNodesAsync(mediator, (master, _selectionRequiringLoad));
 
             sentFieldSets.Should().HaveCount(2);
             results.Single().Should().HaveCount(201);
@@ -234,7 +238,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             };
 
             var results = await ResolveVariationNodesAsync(
-                mediator, (masterA, new[] { "id", "name" }), (masterB, new[] { "id", "name" }));
+                mediator, (masterA, _selectionRequiringLoad), (masterB, _selectionRequiringLoad));
 
             sentFieldSets.Should().HaveCount(1);
 
@@ -256,7 +260,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ["v1", "gone"],
             };
 
-            var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name" }));
+            var results = await ResolveVariationNodesAsync(mediator, (master, _selectionRequiringLoad));
 
             results.Single().Select(x => x.Id).Should().Equal("v1");
         }
@@ -273,7 +277,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ["active1", "inactive"],
             };
 
-            var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name" }));
+            var results = await ResolveVariationNodesAsync(mediator, (master, _selectionRequiringLoad));
 
             results.Single().Select(x => x.Id).Should().Equal("active1");
         }
@@ -292,7 +296,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 })
                 .ToList();
 
-            var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, new[] { "id", "name" })).ToArray());
+            var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, _selectionRequiringLoad)).ToArray());
 
             for (var i = 0; i < masters.Count; i++)
             {
@@ -362,7 +366,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             return (ExpVariation)value;
         }
 
-        private static IResolveFieldContext CreateResolveContext(ExpProduct source, IMediator mediator, string[] subFields)
+        private static ResolveFieldContext CreateResolveContext(ExpProduct source, IMediator mediator, string[] subFields)
         {
             var serviceProviderMock = new Mock<IServiceProvider>();
             serviceProviderMock.Setup(x => x.GetService(typeof(IMediator))).Returns(mediator);
@@ -378,7 +382,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             };
         }
 
-        private static IMediator CreateRecordingMediator(IList<IList<string>> sentFieldSets)
+        private static IMediator CreateRecordingMediator(List<IList<string>> sentFieldSets)
         {
             var mediatorMock = new Mock<IMediator>();
 
@@ -398,7 +402,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             return mediatorMock.Object;
         }
 
-        private static IMediator CreateRecordingMediator(IList<IList<string>> sentFieldSets, Func<string, bool> isActive)
+        private static IMediator CreateRecordingMediator(List<IList<string>> sentFieldSets, Func<string, bool> isActive)
         {
             var mediatorMock = new Mock<IMediator>();
 
@@ -418,7 +422,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             return mediatorMock.Object;
         }
 
-        private static IMediator CreateRecordingMediator(IList<IList<string>> sentFieldSets, ISet<string> unresolvedIds)
+        private static IMediator CreateRecordingMediator(List<IList<string>> sentFieldSets, HashSet<string> unresolvedIds)
         {
             var mediatorMock = new Mock<IMediator>();
 

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
@@ -202,6 +202,45 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
         }
 
         [Fact]
+        public async Task ResolveVariationsField_SelectionIsTypeNameAlone_SendsNoLoadProductsQuery()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets);
+
+            var master = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
+                IndexedVariationIds = ["v1", "v2"],
+            };
+
+            // __typename needs no data at all, so this is answerable from the master's document. Reading the gate's
+            // first operand off the filtered list instead of the raw selection sends it to the loader instead.
+            var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "__typename" }));
+
+            sentFieldSets.Should().BeEmpty();
+            results.Single().Select(x => x.Id).Should().Equal("v1", "v2");
+        }
+
+        [Fact]
+        public async Task ResolveVariationsField_SelectionResolvesToNothing_SendsTheQuery()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets);
+
+            var master = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
+                IndexedVariationIds = ["v1", "v2"],
+            };
+
+            // An empty walk result is ambiguous - nothing was selected, or nothing the walker recognised - and only
+            // loading answers both readings. Dropping the gate's first operand serves it from the master instead.
+            await ResolveVariationNodesAsync(mediator, (master, []));
+
+            sentFieldSets.Should().HaveCount(1);
+        }
+
+        [Fact]
         public async Task ResolveVariationsField_IdsExceedTheBatchCap_SplitsIntoTwoLoadProductsQueries()
         {
             var sentFieldSets = new List<IList<string>>();

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GraphQL;
+using GraphQL.DataLoader;
+using GraphQL.Types;
+using GraphQLParser.AST;
+using MediatR;
+using Moq;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+using VirtoCommerce.XCatalog.Core.Models;
+using VirtoCommerce.XCatalog.Core.Queries;
+using VirtoCommerce.XCatalog.Core.Schemas;
+using VirtoCommerce.XCatalog.Tests.Helpers;
+using Xunit;
+
+namespace VirtoCommerce.XCatalog.Tests.Schemas
+{
+    /// <summary>
+    /// The subject is the number of <see cref="LoadProductsQuery"/> sends a page of masters produces, not the
+    /// variations that come back: the returned variations are correct both before and after batching, so only
+    /// the send count scales with the bug.
+    /// </summary>
+    public class ProductTypeVariationsBatchingTests : XCatalogMoqHelper
+    {
+        [Fact]
+        public async Task ResolveVariationsField_ThreeMastersOnOnePage_SendsOneLoadProductsQuery()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets);
+
+            var masters = new[] { "m1", "m2", "m3" }
+                .Select((id, i) => new ExpProduct
+                {
+                    IndexedProduct = new CatalogProduct { Id = id, IsActive = true },
+                    IndexedVariationIds = [$"v{i}a", $"v{i}b"],
+                })
+                .ToList();
+
+            // "name" alongside "id" keeps the selection deliberately not id-only, so this exercises batching
+            // rather than any selection that can be answered from the master's own document.
+            var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, new[] { "id", "name" })).ToArray());
+
+            sentFieldSets.Should().HaveCount(1);
+            results.SelectMany(x => x).Should().HaveCount(6);
+        }
+
+        [Fact]
+        public async Task ResolveVariationsField_TwoAliasesWithDifferentSubfields_DoNotShareALoader()
+        {
+            var sentFieldSets = new List<IList<string>>();
+            var mediator = CreateRecordingMediator(sentFieldSets);
+
+            var master = new ExpProduct
+            {
+                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
+                IndexedVariationIds = ["v1", "v2"],
+            };
+
+            // Neither alias is id-only: a later gate short-circuits an id-only selection before the loader is
+            // reached, which would make this test fail for a reason that is not the key.
+            await ResolveVariationNodesAsync(mediator, (master, ["id", "name"]), (master, ["id", "code"]));
+
+            sentFieldSets.Should().HaveCount(2);
+
+            // Compare the CONTENT of the two field sets, not the two list objects: OnlyHaveUniqueItems over
+            // IList<string> compares references, which differ by construction, so it would pass against a
+            // loader key that ignores the field set entirely.
+            sentFieldSets
+                .Select(x => string.Join(',', x.OrderBy(f => f, StringComparer.Ordinal)))
+                .Should().OnlyHaveUniqueItems();
+        }
+
+        /// <summary>
+        /// Drives the registered <c>variations</c> field over several sibling nodes sharing one
+        /// <see cref="DataLoaderContext"/>, the way one request does.
+        /// </summary>
+        private async Task<IList<IList<ExpVariation>>> ResolveVariationNodesAsync(
+            IMediator mediator,
+            params (ExpProduct Master, string[] SubFields)[] nodes)
+        {
+            // A mock IDataLoaderContextAccessor returns a null Context, and the loader would never be reached.
+            _dataLoaderContextAccessorMock.Setup(x => x.Context).Returns(new DataLoaderContext());
+
+            var productType = new ProductType(_dataLoaderContextAccessorMock.Object);
+            var variationsField = productType.Fields.First(x => x.Name.EqualsIgnoreCase("variations"));
+
+            // Every node must be resolved - and its loader result queued - before the first one is completed.
+            // This mirrors the execution strategy, which runs ExecuteNodeAsync across sibling nodes and only
+            // then completes the pending data-loader nodes. Resolving and completing one node at a time
+            // dispatches a batch of one each time and reports one send per node against a correctly batched
+            // implementation - a failure that is not the bug.
+            var pending = new List<object>();
+            foreach (var (master, subFields) in nodes)
+            {
+                pending.Add(await variationsField.Resolver.ResolveAsync(CreateResolveContext(master, mediator, subFields)));
+            }
+
+            var results = new List<IList<ExpVariation>>();
+            foreach (var item in pending)
+            {
+                results.Add(await CompleteNodeAsync(item));
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Completes one resolved node the way the execution strategy does - by the resolved value's runtime
+        /// type. A resolver that loaded eagerly hands back the finished sequence instead of a pending result.
+        /// </summary>
+        private static async Task<IList<ExpVariation>> CompleteNodeAsync(object resolved)
+        {
+            var value = resolved is IDataLoaderResult loaderResult
+                ? await loaderResult.GetResultAsync()
+                : resolved;
+
+            return ((IEnumerable<ExpVariation>)value).ToList();
+        }
+
+        private static IResolveFieldContext CreateResolveContext(ExpProduct source, IMediator mediator, string[] subFields)
+        {
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            serviceProviderMock.Setup(x => x.GetService(typeof(IMediator))).Returns(mediator);
+
+            return new ResolveFieldContext
+            {
+                Source = source,
+                // GetCatalogQuery reaches the current principal through a GraphQLUserContext cast, which a plain
+                // dictionary fails.
+                UserContext = new GraphQLUserContext(null) { { "cultureName", CULTURE_NAME } },
+                // The resolver reaches the mediator through context.GetMediator(), which requires RequestServices.
+                RequestServices = serviceProviderMock.Object,
+                SubFields = subFields.ToDictionary(
+                    x => x,
+                    x => (new GraphQLField(new GraphQLName(x)), (FieldType)null)),
+            };
+        }
+
+        private static IMediator CreateRecordingMediator(IList<IList<string>> sentFieldSets)
+        {
+            var mediatorMock = new Mock<IMediator>();
+
+            mediatorMock
+                .Setup(x => x.Send(It.IsAny<LoadProductsQuery>(), It.IsAny<CancellationToken>()))
+                .Returns((LoadProductsQuery query, CancellationToken _) =>
+                {
+                    sentFieldSets.Add(query.IncludeFields.ToList());
+
+                    var products = query.ObjectIds
+                        .Select(id => new ExpProduct { IndexedProduct = new CatalogProduct { Id = id, IsActive = true } })
+                        .ToList();
+
+                    return Task.FromResult(new LoadProductResponse(products));
+                });
+
+            return mediatorMock.Object;
+        }
+    }
+}

--- a/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
+++ b/tests/VirtoCommerce.XCatalog.Tests/Schemas/ProductTypeVariationsBatchingTests.cs
@@ -23,9 +23,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
 {
     public class ProductTypeVariationsBatchingTests : XCatalogMoqHelper
     {
-        // "name" is not one of the fields the master's document answers, so this selection is the one that
-        // reaches the loader. Tests about batching use it; tests about the gate spell their selection out.
-        private static readonly string[] _selectionRequiringLoad = ["id", "name"];
+        private static readonly string[] _subFields = ["id", "name"];
 
         private readonly ProductType _productType;
 
@@ -50,7 +48,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 })
                 .ToList();
 
-            var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, _selectionRequiringLoad)).ToArray());
+            var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, _subFields)).ToArray());
 
             sentFieldSets.Should().HaveCount(1);
             results.SelectMany(x => x).Should().HaveCount(6);
@@ -91,7 +89,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 .ToList();
 
             var results = await ResolveMasterVariationNodesAsync(
-                mediator, variations.Select(x => (x, _selectionRequiringLoad)).ToArray());
+                mediator, variations.Select(x => (x, _subFields)).ToArray());
 
             sentFieldSets.Should().HaveCount(1);
 
@@ -118,8 +116,8 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             var variationsField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("variations"));
             var masterVariationField = _productType.Fields.First(x => x.Name.EqualsIgnoreCase("masterVariation"));
 
-            var pendingVariations = await variationsField.Resolver.ResolveAsync(CreateResolveContext(master, mediator, _selectionRequiringLoad));
-            var pendingMasterVariation = await masterVariationField.Resolver.ResolveAsync(CreateResolveContext(variation, mediator, _selectionRequiringLoad));
+            var pendingVariations = await variationsField.Resolver.ResolveAsync(CreateResolveContext(master, mediator, _subFields));
+            var pendingMasterVariation = await masterVariationField.Resolver.ResolveAsync(CreateResolveContext(variation, mediator, _subFields));
 
             var resolvedVariations = await CompleteNodeAsync(pendingVariations);
             var resolvedMasterVariation = await CompleteMasterVariationNodeAsync(pendingMasterVariation);
@@ -130,7 +128,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
         }
 
         [Fact]
-        public async Task ResolveVariationsField_SelectionIsIdOnly_SendsNoLoadProductsQuery()
+        public async Task ResolveVariationsField_SelectionIsIdOnly_SendsTheQuery()
         {
             var sentFieldSets = new List<IList<string>>();
             var mediator = CreateRecordingMediator(sentFieldSets);
@@ -141,103 +139,13 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ["v1", "v2"],
             };
 
+            // Answering this from the master's own document is the tempting shortcut, and it drops the
+            // startDate/endDate window that the search applies to every other selection - so an id-only
+            // selection would return variations outside their validity window that "id name" filters out.
             var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id" }));
 
-            sentFieldSets.Should().BeEmpty();
-            results.Single().Select(x => x.Id).Should().Equal("v1", "v2");
-        }
-
-        [Fact]
-        public async Task ResolveVariationsField_SelectionNeedsALoadedField_StillSendsTheQuery()
-        {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets);
-
-            var master = new ExpProduct
-            {
-                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
-                IndexedVariationIds = ["v1", "v2"],
-            };
-
-            await ResolveVariationNodesAsync(mediator, (master, _selectionRequiringLoad));
-
             sentFieldSets.Should().HaveCount(1);
-        }
-
-        [Fact]
-        public async Task ResolveVariationsField_SelectionIsIdAndTypeName_SendsNoLoadProductsQuery()
-        {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets);
-
-            var master = new ExpProduct
-            {
-                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
-                IndexedVariationIds = ["v1", "v2"],
-            };
-
-            // This, not the bare id-only case, is what an id-only source query looks like on the wire: a client
-            // that normalises a cache adds __typename to every selection set.
-            var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "__typename" }));
-
-            sentFieldSets.Should().BeEmpty();
             results.Single().Select(x => x.Id).Should().Equal("v1", "v2");
-        }
-
-        [Fact]
-        public async Task ResolveVariationsField_SelectionIsTypeNameBesideALoadedField_StillSendsTheQuery()
-        {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets);
-
-            var master = new ExpProduct
-            {
-                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
-                IndexedVariationIds = ["v1", "v2"],
-            };
-
-            await ResolveVariationNodesAsync(mediator, (master, new[] { "id", "name", "__typename" }));
-
-            sentFieldSets.Should().HaveCount(1);
-        }
-
-        [Fact]
-        public async Task ResolveVariationsField_SelectionIsTypeNameAlone_SendsNoLoadProductsQuery()
-        {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets);
-
-            var master = new ExpProduct
-            {
-                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
-                IndexedVariationIds = ["v1", "v2"],
-            };
-
-            // __typename needs no data at all, so this is answerable from the master's document. Reading the gate's
-            // first operand off the filtered list instead of the raw selection sends it to the loader instead.
-            var results = await ResolveVariationNodesAsync(mediator, (master, new[] { "__typename" }));
-
-            sentFieldSets.Should().BeEmpty();
-            results.Single().Select(x => x.Id).Should().Equal("v1", "v2");
-        }
-
-        [Fact]
-        public async Task ResolveVariationsField_SelectionResolvesToNothing_SendsTheQuery()
-        {
-            var sentFieldSets = new List<IList<string>>();
-            var mediator = CreateRecordingMediator(sentFieldSets);
-
-            var master = new ExpProduct
-            {
-                IndexedProduct = new CatalogProduct { Id = "m1", IsActive = true },
-                IndexedVariationIds = ["v1", "v2"],
-            };
-
-            // An empty walk result is ambiguous - nothing was selected, or nothing the walker recognised - and only
-            // loading answers both readings. Dropping the gate's first operand serves it from the master instead.
-            await ResolveVariationNodesAsync(mediator, (master, []));
-
-            sentFieldSets.Should().HaveCount(1);
         }
 
         [Fact]
@@ -253,7 +161,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ids,
             };
 
-            var results = await ResolveVariationNodesAsync(mediator, (master, _selectionRequiringLoad));
+            var results = await ResolveVariationNodesAsync(mediator, (master, _subFields));
 
             sentFieldSets.Should().HaveCount(2);
             results.Single().Should().HaveCount(201);
@@ -277,7 +185,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
             };
 
             var results = await ResolveVariationNodesAsync(
-                mediator, (masterA, _selectionRequiringLoad), (masterB, _selectionRequiringLoad));
+                mediator, (masterA, _subFields), (masterB, _subFields));
 
             sentFieldSets.Should().HaveCount(1);
 
@@ -299,7 +207,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ["v1", "gone"],
             };
 
-            var results = await ResolveVariationNodesAsync(mediator, (master, _selectionRequiringLoad));
+            var results = await ResolveVariationNodesAsync(mediator, (master, _subFields));
 
             results.Single().Select(x => x.Id).Should().Equal("v1");
         }
@@ -316,7 +224,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 IndexedVariationIds = ["active1", "inactive"],
             };
 
-            var results = await ResolveVariationNodesAsync(mediator, (master, _selectionRequiringLoad));
+            var results = await ResolveVariationNodesAsync(mediator, (master, _subFields));
 
             results.Single().Select(x => x.Id).Should().Equal("active1");
         }
@@ -335,7 +243,7 @@ namespace VirtoCommerce.XCatalog.Tests.Schemas
                 })
                 .ToList();
 
-            var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, _selectionRequiringLoad)).ToArray());
+            var results = await ResolveVariationNodesAsync(mediator, masters.Select(x => (x, _subFields)).ToArray());
 
             for (var i = 0; i < masters.Count; i++)
             {


### PR DESCRIPTION
## Description

A listing page issued one Elasticsearch product search **per variation-bearing product**: `ProductType`'s `variations` resolver sent a `LoadProductsQuery` for each master's own variation-id list, and `masterVariation` sent one per node for a single id. No arguments cache collapses these — the id sets are disjoint across masters, so every call is a genuine miss.

Both fields now resolve through one shared DataLoader batch, so a page issues **one** search regardless of how many masters it renders. Two details bound that claim: the batch is capped at 200 ids, so a page whose masters carry more splits into the corresponding number of searches; and the requested subfield set is part of the loader key, so two aliases of the field selecting different subfields are two batches rather than one under-selected result.

No GraphQL schema change — no new type, field or argument, and no output type changed shape. No migrations, no new settings, no new dependencies.

## New GraphQL queries and mutations

None — this PR adds no query, mutation or type.

## Changes to existing GraphQL queries and mutations

No shape or argument changes. `Product.variations` and `Product.masterVariation` take the same arguments and return the same types as before.

One observable behaviour change, on `Product.variations`:

- **Result order.** Variations now come back in the order of the master document's variation-id list. Previously they came back in whatever order the index search returned them: the resolver passed the id list to `LoadProductsQuery` and projected the response as it arrived. The new order is a consequence of batching — the loader keys the response by product id and emits one result per requested id — so it holds for every selection. A client that depended on the old order depended on something the API never guaranteed, but the order does change.

Unchanged: the active-only filter on `variations`, the deliberate absence of that filter on `masterVariation` (an inactive main product is still returned), an unresolved id being absent from the result rather than null, and the empty result for a master with no variations.

## New public services / interfaces / methods

None — this PR adds no `public` member.

## New protected methods (extensibility)

- **`protected virtual IDataLoaderResult<IList<ExpVariation>> ResolveVariations(IResolveFieldContext context, IList<string> variationIds, bool onlyActive)`** — the seam both fields now resolve through. Override it to change which ids are loaded, how they are projected, or whether the active-only filter applies. Note it is shared: `variations` calls it with `onlyActive: true`, `masterVariation` with `onlyActive: false`, so an override intercepts both fields.

`ResolveVariationsFieldAsync` keeps its `protected virtual` modifier, its parameter and its `Task<object>` return type, and remains the registered resolver for `variations` — but is now deprecated; see below.

## Breaking changes

**`ResolveVariationsFieldAsync` is deprecated** — `[Obsolete("Use ResolveVariations.", DiagnosticId = "VC0015")]`. Binary compatibility is preserved and the member still runs; the deprecation is the loud compile-time notice that consumers should move before it is removed.

- **A consumer that overrides it gets `CS0672`** ("member overrides obsolete member"), whether or not it calls `base`. Note this is the stock compiler diagnostic, **not** `VC0015` — so the usual `#pragma warning disable VC0015` does not silence it. Migration is to override `ResolveVariations` instead, which clears the diagnostic; with `TreatWarningsAsErrors` set, as it is here and across sibling modules, the unmigrated override is a build error.
- **A consumer that calls `base` also gets `VC0015`** at the call site.
- **The runtime type behind `ResolveVariationsFieldAsync` changed.** It resolved to an `IEnumerable<ExpVariation>` and now resolves to an `IDataLoaderResult<IList<ExpVariation>>`. The declared `Task<object>` is unchanged, so this alone compiles — but an override that calls `base` and casts the result to `IEnumerable<ExpVariation>` fails at runtime. This is inherent to resolving through a DataLoader: `FieldCreator.CreateFieldAsync` erases the declared type into `ValueTask<object>`, and the execution engine tests the resolved value for `IDataLoaderResult` and completes it itself.

No signatures changed and no members were removed.

## New dependencies

None. No `PackageReference` and no `module.manifest` entry was added or changed: `GetOrAddBatchLoader` comes from the already-referenced `GraphQL.DataLoader`.

---

> **Note (an id-only fast path was tried and withdrawn).** An earlier revision of this branch also answered `variations { id }` from the master's own `IndexedVariationIds` without loading at all, since those ids are on the master's document already. It does not hold. Every product search is built through `SearchProductQueryHandler.GetIndexedSearchRequestBuilder`, which adds `AddCertainDateFilter` in its unconditional chain — the `request.ObjectIds.IsNullOrEmpty()` guard below it gates only `AddDefaultTerms`, and the resulting `startdate`/`enddate` range filters AND with the ids filter rather than replacing it. So the loaded path enforces a validity window a master-document answer cannot express, in both directions: a variation whose `StartDate` has not yet arrived, and one whose `EndDate` has passed. Since `dev` routes every selection through that query, keeping the shortcut would have made `variations { id }` return a superset of `variations { id name }` for one product at one instant. Answering an id-only selection correctly would mean carrying each variation's validity window on the master's document — a catalog-indexer change, and a separate ticket. `ResolveVariationsField_SelectionIsIdOnly_SendsTheQuery` pins the decision: re-introducing the shortcut turns it red.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5689
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.1017.0-pr-108-e6b1.zip



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> GraphQL catalog resolution and a deprecated protected override seam change runtime types and variation ordering; no schema or auth changes, but storefronts or modules that depended on search order or override `ResolveVariationsFieldAsync` may break.
> 
> **Overview**
> **Batches variation product loads** so listing pages no longer issue one `LoadProductsQuery` per master or per `masterVariation` node. `Product.variations` and `Product.masterVariation` now share a `GetOrAddBatchLoader` keyed by requested subfields (cap **200** ids per batch).
> 
> `masterVariation` moves to a synchronous `IDataLoaderResult` resolver; `variations` still registers the old async entry point but delegates to new **`ResolveVariations`**. **`ResolveVariationsFieldAsync` is obsolete** (`VC0015`)—overrides should move to `ResolveVariations`; the resolved value is now `IDataLoaderResult<IList<ExpVariation>>` instead of a plain enumerable.
> 
> **Observable behavior:** `variations` order now follows the master’s `IndexedVariationIds` list (not search result order). Active-only filtering on `variations`, no filter on `masterVariation`, and id-only selections still go through search (validity window)—unchanged aside from order.
> 
> Adds **`ProductTypeVariationsBatchingTests`** covering batching, loader key separation, batch cap, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59ad612b44eea2dfab6e35e40943e3941b21f78b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


