### PR TITLE
VCST-5691: Create ProductPrice with AbstractTypeFactory

### DIFF
--- a/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/ProductType.cs
@@ -319,7 +319,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             ExtendableField<NonNullGraphType<PriceType>>(
                 "price",
                 "Product price",
-                resolve: context => context.Source.AllPrices.FirstOrDefault() ?? new ProductPrice(context.GetCurrencyByCode(context.GetValue<string>("currencyCode"))));
+                resolve: context => context.Source.AllPrices.FirstOrDefault() ?? AbstractTypeFactory<ProductPrice>.TryCreateInstance(nameof(ProductPrice), context.GetCurrencyByCode(context.GetValue<string>("currencyCode"))));
 
             ExtendableField<NonNullGraphType<ListGraphType<NonNullGraphType<PriceType>>>>(
                 "prices",

--- a/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
+++ b/src/VirtoCommerce.XCatalog.Core/Schemas/VariationType.cs
@@ -59,7 +59,7 @@ namespace VirtoCommerce.XCatalog.Core.Schemas
             ExtendableField<NonNullGraphType<PriceType>>(
                 "price",
                 "Product price",
-                resolve: context => context.Source.AllPrices.FirstOrDefault() ?? new ProductPrice(context.GetCurrencyByCode(context.GetValue<string>("currencyCode"))));
+                resolve: context => context.Source.AllPrices.FirstOrDefault() ?? AbstractTypeFactory<ProductPrice>.TryCreateInstance(nameof(ProductPrice), context.GetCurrencyByCode(context.GetValue<string>("currencyCode"))));
 
             ExtendableField<NonNullGraphType<ListGraphType<NonNullGraphType<PriceType>>>>(
                 "prices",

--- a/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
+++ b/src/VirtoCommerce.XCatalog.Core/VirtoCommerce.XCatalog.Core.csproj
@@ -13,6 +13,6 @@
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1057.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1018.0-alpha.195-vcst-5691" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XCatalog.Data/Mapping/ProductMappingProfile.cs
+++ b/src/VirtoCommerce.XCatalog.Data/Mapping/ProductMappingProfile.cs
@@ -113,15 +113,12 @@ namespace VirtoCommerce.XCatalog.Data.Mapping
                         var currency = allCurrencies[price.Currency];
                         if (currency != null)
                         {
-                            var productPrice = new ProductPrice(currency)
-                            {
-                                ProductId = price.ProductId,
-                                PricelistId = price.PricelistId,
-                                Currency = currency,
-                                StartDate = price.StartDate,
-                                EndDate = price.EndDate,
-                                ListPrice = new Money(price.List, currency)
-                            };
+                            var productPrice = AbstractTypeFactory<ProductPrice>.TryCreateInstance(nameof(ProductPrice), currency);
+                            productPrice.ProductId = price.ProductId;
+                            productPrice.PricelistId = price.PricelistId;
+                            productPrice.StartDate = price.StartDate;
+                            productPrice.EndDate = price.EndDate;
+                            productPrice.ListPrice = new Money(price.List, currency);
                             productPrice.SalePrice = price.Sale == null ? productPrice.ListPrice : new Money(price.Sale ?? 0m, currency);
                             productPrice.MinQuantity = price.MinQuantity;
 

--- a/src/VirtoCommerce.XCatalog.Web/module.manifest
+++ b/src/VirtoCommerce.XCatalog.Web/module.manifest
@@ -10,7 +10,7 @@
     <dependency id="VirtoCommerce.Inventory" version="3.1003.0" optional="true" />
     <dependency id="VirtoCommerce.Marketing" version="3.1005.0" optional="true" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" optional="true" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1015.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1018.0-alpha.195-vcst-5691" />
   </dependencies>
 
   <title>Catalog Experience API</title>


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5691
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCatalog_3.1017.0-pr-109-1253.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches catalog pricing and GraphQL price fallbacks; behavior should match if the factory resolves the default type, but the alpha Xapi dependency adds integration risk until a stable release ships.
> 
> **Overview**
> **ProductPrice** instances are no longer constructed with `new`; they are created through `AbstractTypeFactory<ProductPrice>.TryCreateInstance(nameof(ProductPrice), currency)` so custom or extended price types from Xapi can be used consistently.
> 
> This applies to the GraphQL `price` fallback on **Product** and **Variation**, and to price mapping in `ProductMappingProfile` when converting indexed `Price` rows (property assignment is unchanged; `Currency` is no longer set manually on the mapped object).
> 
> **VirtoCommerce.Xapi.Core** and the **VirtoCommerce.Xapi** module dependency are bumped to `3.1018.0-alpha.195-vcst-5691` to align with the factory API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12532d1513652333539ca40d5deaaeefbec74979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->